### PR TITLE
confdgnmi next milestone (STREAMing subscription)

### DIFF
--- a/.github/workflows/confdgnmi.yml
+++ b/.github/workflows/confdgnmi.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Confd gNMI Apdaper
+
+on:
+  push:
+    branches: [ master confdgnmi confdgnmi-adapter]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest grpcio-tools
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          PYTHONPATH=./confdgnmi/src:./confdgnmi/tests:${PYTHONPATH} pytest  -s -v -m "not confd" confdgnmi/tests

--- a/confdgnmi/Makefile
+++ b/confdgnmi/Makefile
@@ -37,9 +37,12 @@ PCG_DIR=$(SRC_DIR)
 
 
 all: gnmi_proto \
-	iana-if-type.fxs ietf-interfaces.fxs  \
+	iana-if-type.fxs ietf-interfaces.fxs src/ietf-interfaces_ns.py \
 	$(CDB_DIR) ssh-keydir init_interfaces.xml
 	@echo "Build complete"
+
+src/ietf-interfaces_ns.py: ietf-interfaces.fxs
+	$(CONFDC) --emit-python src/ietf-interfaces_ns.py ietf-interfaces.fxs
 
 init_interfaces.xml:
 	  ./datagen.py 10

--- a/confdgnmi/data/demo.xml
+++ b/confdgnmi/data/demo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<demo>
+  <subscription>
+    <STREAM>
+      <changes>
+        <element>
+          <path>/interfaces/interface[name=if_5]/type</path>
+          <val>fastEther</val>
+        </element>
+        <element>
+          <path>/interfaces-state/interface[name=state_if_5]/type</path>
+          <val>fastEther</val>
+        </element>
+        <element>
+          <path>/interfaces/interface[name=if_6]/type</path>
+          <val>fastEther</val>
+        </element>
+        <element>
+          <path>/interfaces-state/interface[name=state_if_6]/type</path>
+          <val>fastEther</val>
+        </element>
+        <element>send</element>
+        <element>
+          <path>/interfaces/interface[name=if_5]/type</path>
+          <val>gigabitEthernet</val>
+        </element>
+        <element>
+          <path>/interfaces-state/interface[name=state_if_5]/type</path>
+          <val>gigabitEthernet</val>
+        </element>
+        <element>send</element>
+        <element>
+          <path>/interfaces/interface[name=if_6]/type</path>
+          <val>gigabitEthernet</val>
+        </element>
+        <element>
+          <path>/interfaces-state/interface[name=state_if_6]/type</path>
+          <val>gigabitEthernet</val>
+        </element>
+        <element>send</element>
+      </changes>
+    </STREAM>
+  </subscription>
+</demo>

--- a/confdgnmi/docs/ConfD_gNMI_adapter.adoc
+++ b/confdgnmi/docs/ConfD_gNMI_adapter.adoc
@@ -67,7 +67,7 @@ pip install grpcio-tools
 
 NOTE: make sure all commands have executed - confirm last command with kbd:[ENTER], if needed.
 If viewed on https://github.com[GitHub], you may find following
-browser https://github.com/zenorocha/codecopy[extension] useful (oyt of the box *copy to clipboard* button).
+browser https://github.com/zenorocha/codecopy[extension] useful (out-of-the-box *copy to clipboard* button).
 
 The output of the shell CLI commands or file content will be displayed
 with following block style:
@@ -746,7 +746,7 @@ This not all gNMI functionality are currently supported. They may be added in th
 * `Get`, `Set` and `Subscribe` works only on `the leaf`, list` entries and `lists`
 * `Set` works only on `leaf` elements
 * `Subscribe`
-** Not all subscription parameters are supported
+** not all subscription parameters are supported
 ** `updates_only` not supported
 ** `heartbeat_interval` not supported
 * * `sync_response` not generated

--- a/confdgnmi/docs/ConfD_gNMI_adapter.adoc
+++ b/confdgnmi/docs/ConfD_gNMI_adapter.adoc
@@ -7,7 +7,8 @@
 
 ifdef::env-github[]
 //https://github.com/DBuret/journal/blob/master/github-adoc-puml.adoc
-:gitplant: http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/micnovak/ConfD-Demos/confdgnmi-develop/confdgnmi/docs
+:gitplant: http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/ConfD-Developer/ConfD-Demos/master/confdgnmi/docs
+:gitplant-develop: http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/micnovak/ConfD-Demos/confdgnmi-develop/confdgnmi/docs
 :caution-caption: :fire:
 :important-caption: :exclamation:
 :note-caption: :information_source:
@@ -21,15 +22,16 @@ endif::[]
 :Author:    Michal Novák
 :email:     micnovak@cisco.com
 :URL:       https://www.tail-f.com/
-:Date:      2021-02-09
-:Revision:  0.0.1
+:Date:      2021-03-23
+:Revision:  0.1.0
 
 == Version history
 
 [options="header", cols="1s,10,^2s,2e"]
 |======
 | Document version     | Notes                                                  | Date        | Author
-| {revision}           | Initial document version                       | {date}      | {author} {email}
+| 0.0.1           | Initial document version                       | 2021-02-09      | {author} {email}
+| {revision}           | Run options updated, added seq. diagrams for Subscribe operation                      | {date}      | {author} {email}
 |======
 
 toc::[]
@@ -47,14 +49,16 @@ https://www.tail-f.com/management-agent/[ConfD] is configuration management agen
 
 https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md[gNMI] is another popular north bound interface, which is not implemented by ConfD.
 In this demo project we will implement gNMI adapter over existing ConfD interfaces to make (at least partial) gNMI support.
-In the beginning we will provide basic functionality, for most common operations, later on we will add more.
+In the beginning, we will provide basic functionality, for most common operations, later on we will add more.
 This demo focuses on functionality and simplicity, we have chosen Python as implementation language.
 
-This demo is still work in progress, see <<_limitations_and_todos>> section.
+We try general approach, so the demo can be adapted for other tools as well.
+
+This demo is still work in progress, see <<Limitations and TODOs>> section.
 
 === Copy/Paste and Output blocks
 
-In this note you will find script and code examples, that can be directly pasted into shell or CLI terminal. We will use following block style for copy/paste ready text:
+In this note you can find script and code examples, that can be directly pasted into shell or CLI terminal. We will use following block style for the copy/paste ready text:
 
 [source,shell,role="acopy"]
 ----
@@ -63,7 +67,7 @@ pip install grpcio-tools
 
 NOTE: make sure all commands have executed - confirm last command with kbd:[ENTER], if needed.
 If viewed on https://github.com[GitHub], you may find following
-browser https://github.com/zenorocha/codecopy[extension] useful, to get out of the box copy to clipboard button.
+browser https://github.com/zenorocha/codecopy[extension] useful (oyt of the box *copy to clipboard* button).
 
 The output of the shell CLI commands or file content will be displayed
 with following block style:
@@ -74,6 +78,7 @@ with following block style:
 Usage: confd_gnmi_server.py [options]
 
 Options:
+  --version             show program's version number and exit
   -h, --help            show this help message and exit
   -t TYPE, --type=TYPE  gNMI server type  [api, netconf, demo]
   --logging=LOGGING     Logging level [error, warning, info, debug]
@@ -83,13 +88,14 @@ Options:
                         ConfD IP address (default is 127.0.0.1)
   --confd-port=CONFD_PORT
                         ConfD port (default is 4565)
+  --cfg=CFG             config file
 ----
 
 == Dependencies
 
 === Python3
 
-We expect https://www.python.org/[Python3] to be installed and that `python` nad `pip` are from Python3 environment. If not, use `python3` or `pip3` instead (or use e.g. `sudo apt-get install python-is-python3`)
+We expect https://www.python.org/[Python3] to be installed and `python` nad `pip` commands are from Python3 environment. If not, use `python3` or `pip3` instead (or use e.g. `sudo apt-get install python-is-python3`)
 
 TIP: For package installation and development, you may consider creating https://docs.python.org/3/tutorial/venv.html[python virtual environment].
 
@@ -128,11 +134,11 @@ pip install pytest
 pip install --upgrade pytest
 ----
 
-NOTE: pytest may be available also as package in your distribution (e.g. `apt-get install python3-pytest`). We still recommend to use `pip` to get the latest version.
+NOTE: `pytest` may be available also as package in your distribution (e.g. `apt-get install python3-pytest`). We still recommend to use `pip` to get the latest version.
 
 === ConfD
 
-Install https://www.tail-f.com/management-agent/[ConfD Premium] or https://www.tail-f.com/confd-basic/[ConfD Basic] according to the description in the package (`README`). To set-up ConfD environment, source `confdrc`.
+Install https://www.tail-f.com/management-agent/[ConfD Premium] or https://www.tail-f.com/confd-basic/[ConfD Basic] according to the description in the package (`README`). To set up ConfD environment, source `confdrc`.
 
 .set-up ConfD envrionment
 [source, shell, role="acopy"]
@@ -189,7 +195,7 @@ NOTE: There is a `Makefile` target `gnmi_proto` that performs this build.
 The `Makefile` can build ConfD datamodel binary file (`fxs`) for
 https://tools.ietf.org/html/rfc8343[`ietf-interfaces.yang`] and its dependencies. It can also prepare some initial configuration (`interfaces.xml`). See `Makefile` target `all`.
 
-NOTE: The used datamodel and initial configuration is used for demonstration in this note. The gNMI adapter can run against any other ConfD instance with different data model. In this case, paths and values will be different. See examples with ConfD example application <<Examples against `examples.confd/intro/5-c_stats`,`5-c_stats`>> and <<Examples against `examples.confd/intro/6-c_config`, `6-c_config`>>.
+NOTE: The used datamodel and initial configuration is used for demonstration in this note. The gNMI adapter can run against any other ConfD instance with different data model. In this case, paths and values will be different. See examples with ConfD example application <<Examples against `examples.confd/intro/5-c_stats`,`5-c_stats`>> and <<Examples against `examples.confd/cdb_subscription/iter_c`, `iter-c`>>.
 
 == Running gNMI Adapter demo
 
@@ -226,6 +232,8 @@ Server is started by running  `./src/confd_gnmi_server.py` python script.
 .output
 [source, shell]
 ----
+Usage: confd_gnmi_server.py [options]
+
 Options:
   --version             show program's version number and exit
   -h, --help            show this help message and exit
@@ -237,9 +245,10 @@ Options:
                         ConfD IP address (default is 127.0.0.1)
   --confd-port=CONFD_PORT
                         ConfD port (default is 4565)
+  --cfg=CFG             config file
 ----
 
-We can run server in demo mode (pass `-t demo`) or in API (`maapi`) mode against ConfD (pass `-t api`). Other modes (like `netconf` are currently not supported).
+We can run server in demo mode type (pass `-t demo`) or in API (`maapi`) mode against ConfD (pass `-t api`). Other modes (like `netconf` are currently not supported). For `demo` mode type, it may be necessary to pass config file (e.g. for `STREAM` subscriptions, `--cfg=data/demo.xml)
 
 NOTE: Other parameters (e.g. port, host) are currently hardcoded in the source code (mainly in the `./src/confd_gnmi_common.py`).
 
@@ -274,9 +283,20 @@ Options:
                         STATE, OPERATIONAL  (default 'CONFIG')
   -v VALS, --val=VALS   'value' for set operation, can be repeated (empty by
                         default)
+  -s SUBMODE, --sub-mode=SUBMODE
+                        subscription mode, can be ONCE, POLL, STREAM (default
+                        'ONCE')
+  --poll-count=POLLCOUNT
+                        Number of POLLs (default 5)
+  --poll-interval=POLLINTERVAL
+                        Interval (in seconds) between POLL requests (default
+                        0.5)
+  --read-count=READCOUNT
+                        Number of read requests for STREAM subscription
+                        (default 4)
 ----
 
-NOTE: Other parameters (e.g. username, password, subscription parameter, data type) are currently hardcoded in the source code (mainly in the `./src/confd_gnmi_client.py`).
+NOTE: Other parameters (e.g. username, password, encoding) are currently hardcoded in the source code (mainly in the `./src/confd_gnmi_client.py`).
 
 ==== Examples
 
@@ -318,11 +338,44 @@ NOTE: Other parameters (e.g. username, password, subscription parameter, data ty
 ./src/confd_gnmi_client.py -o set  --prefix /interfaces --path interface[name=if_8]/type --val fastEther
 ----
 
-.subscribe for `leaf` elements
+.ONCE subscribe for `leaf` elements
 [source, shell, role="acopy"]
 ----
-./src/confd_gnmi_client.py -o subscribe --prefix /interfaces --path interface[name=if_8]/name --path interface[name=if_8]/type
+./src/confd_gnmi_client.py -o subscribe -s ONCE --prefix /interfaces --path interface[name=if_8]/name --path interface[name=if_8]/type
 ----
+
+.POLL subscribe for `leaf` elements
+[source, shell, role="acopy"]
+----
+./src/confd_gnmi_client.py -o subscribe -s POLL --poll-count=2 --poll-interval=1.5 --prefix /interfaces --path interface[name=if_8]/name --path interface[name=if_8]/type
+----
+
+.STREAM subscribe for `leaf` elements
+[source, shell, role="acopy"]
+----
+/src/confd_gnmi_client.py -o subscribe -s STREAM --read-count=3 --prefix /interfaces --path interface[name=if_8]/name --path interface[name=if_8]/type
+----
+
+NOTE: Following subscribe examples use `ONCE` (default) subscription mode. It is possible to use `POLL` (with `--poll-count` and `--poll-interval`) and `STREAM` (with `--read-count`) mode as well.
+
+NOTE: To test `STREAM` subscriptions, one can use `confd_cmd`. +
+Examples for configuration data: +
+ +
+`confd_cmd -c "mset /interfaces/interface{if_8}/type gigabitEthernet"` +
+ +
+`confd_cmd -c "mset /interfaces/interface{if_8}/type fastEther"` +
+ +
+(in one transaction) +
+ +
+`confd_cmd -c "mset /interfaces/interface{if_7}/type gigabitEthernet; mset /interfaces/interface{if_8}/type gigabitEthernet;"`
+ +
+ +
+Examples for operational data: +
+ +
+`confd_cmd -o -fr -c "set /interfaces-state/interface{state_if_8}/type fastEther"` +
+ +
+`confd_cmd -o -fr -c "set /interfaces-state/interface{state_if_8}/type gigabitEthernet"`
+
 
 .subscribe for `list` entry
 [source, shell, role="acopy"]
@@ -375,41 +428,74 @@ NOTE: Other parameters (e.g. username, password, subscription parameter, data ty
 ./src/confd_gnmi_client.py -o subscribe --prefix /arpentries --path arpe
 ----
 
-===== Examples against `examples.confd/intro/6-c_config`
+===== Examples against `examples.confd/cdb_subscription/iter_c`
 
-(`make clean all start` and `netconf-console cmd-create-woody.xml`)
 
-.get `list` entries
+.Start the example
 [source, shell, role="acopy"]
 ----
-./src/confd_gnmi_client.py -o  get --path /hosts/host[name=woody]/interfaces/interface
+make clean all start
 ----
 
-.get `list` entries with prefix
-[source, shell, role="acopy"]
-----
-./src/confd_gnmi_client.py -o  get --prefix /hosts/host[name=woody]/interfaces  --path interface
-----
 
-.get one `list` entry
+.Set example initial configuration
 [source, shell, role="acopy"]
 ----
-./src/confd_gnmi_client.py -o  get --prefix /hosts/host[name=woody]/interfaces  --path interface[name=eth0]
+confd_cmd -c "mcreate /root/node-b/rf-head{10}; mset /root/node-b/rf-head{10}/sector-id id0"
+confd_cmd -c "mcreate /root/node-b/rf-head{11}; mset /root/node-b/rf-head{11}/sector-id id1"
+confd_cmd -c "mcreate /root/node-b/rf-head{12}; mset /root/node-b/rf-head{12}/sector-id id2"
 ----
 
 .get specific `leaf`
 [source, shell, role="acopy"]
 ----
-./src/confd_gnmi_client.py -o  get --prefix /hosts/host[name=woody]/interfaces  --path interface[name=eth0]/ip
+./src/confd_gnmi_client.py -o get --path /root/node-b/rf-head[dn=10]/sector-id
 ----
+
+.get `leaf` with prefix
+[source, shell, role="acopy"]
+----
+./src/confd_gnmi_client.py -o get --prefix /root/node-b/rf-head[dn=10] --path sector-id
+----
+
+.get one `list` entry
+[source, shell, role="acopy"]
+----
+./src/confd_gnmi_client.py -o get --prefix /root/node-b --path rf-head[dn=10]
+----
+
+.get  `list`
+[source, shell, role="acopy"]
+----
+./src/confd_gnmi_client.py -o get --path /root/node-b/rf-head
+----
+
+.set specific `leaf`
+[source, shell, role="acopy"]
+----
+./src/confd_gnmi_client.py -o set --path /root/node-b/rf-head[dn=10]/sector-id --val id100
+----
+
+NOTE: `set` is supported only with CDB RUNNING - see <<Limitations and TODOs>>)
 
 .subscribe for `list` entries
 [source, shell, role="acopy"]
 ----
-./src/confd_gnmi_client.py -o subscribe  --prefix /hosts --path host[name=woody]/interfaces/interface
+./src/confd_gnmi_client.py -o subscribe --prefix /root --path node-b/rf-head[dn=10]
 ----
 
-NOTE: As `examples.confd/intro/6-c_config` uses CANDIDATE DB, `set` is not shown (currently we only support RUNNING DB - see <<_limitations_and_todos>>)
+.subscribe for `list` entries as `STREAM` subscription
+[source, shell, role="acopy"]
+----
+./src/confd_gnmi_client.py -o subscribe -s STREAM --read-count=3 --prefix /root --path node-b/rf-head[dn=10]
+----
+
+TIP: Use gNMI `set` operation or `confd_cmd -c "mset ..."` to invoke changes visible in the STREAMing subscription. +
+E.g.:  `./src/confd_gnmi_client.py -o set --path /root/node-b/rf-head[dn=10]/sector-id --val id1000` or
+`confd_cmd -c "mset /root/node-b/rf-head{10}/sector-id id10000"`
+
+NOTE: Changes to configuration are also visible in the console of started example `examples.confd/cdb_subscription/iter_c` as it uses under ConfD subscriber. It is interesting to compare
+both type of subscriptions.
 
 == Implementation
 
@@ -428,13 +514,12 @@ endif::[]
 * *gNMI Adapter server* - connects to ConfD and uses its northbound interfaces (currently only MAAPI) to provide gNMI functionality. We aim for design that could be adapted to other devices (not only ConfD) with known management interfaces, e.g. devices supporting NETCONF, RESTCONF or mixed interfaces.
 * *gNMI Adapter client* - gNMI client developed in this project for testing and presentation of the functionality
 
-
 === gNMI adapter server sub-components
 
 Following class/component diagram shows main structure of the gNMI adapter server
 
 ifdef::env-github[]
-image::{gitplant}/component.puml[]
+image::{gitplant-develop}/component.puml[]
 endif::[]
 ifndef::env-github[]
 plantuml::component.puml[format="svg", align="center"]
@@ -494,7 +579,7 @@ What should be returned? We return only `updated` paths.
 
 * the `notification` should contain whole subtree for each request path.
 This means, for each request path there will be list of paths in
-`update`, each with value (currently only `leafs` and last `lists` are supported)
+the `update`, each with value (currently only `leafs` and last `lists` are supported)
 
 * since there is a path associated with each value, for requests on nested lists
 we have to find out, which elements are keys and add them to the Path(s).
@@ -527,19 +612,22 @@ We can use `MAAPI` operations, like `set_elem`.
 
 `rpc Subscribe(stream SubscribeRequest) returns (stream SubscribeResponse);`
 
-Stream subscription requests and get stream of subscription responses.
+Send a stream of subscription requests and get stream of subscription responses.
 
-Subscription response is similar to `Get`, this means all data in
-given sub-tree is returned in response.
+In many cases, Subscription response is similar to `Get`, this means all data in
+given sub-tree is returned in response (at least first response).
 
-`ONCE`, `POLL` mode of the `SubscriptionList`:
+All values are sent:
+
+`ONCE`, `POLL` mode of the `SubscriptionList`
 
 * responses according to `heartbeat_interval`,
 * responses to `SAMPLE` mode in the `Subscription` element
 
 Only updated values are sent:
 
-* `STREAM` mode of the `SubscriptionList`
+`STREAM` mode of the `SubscriptionList`
+
 * when `updates_only` is set for `STREAM` mode,
 * when `suppress_redundant` is set for `SAMPLE` mode
 
@@ -549,13 +637,44 @@ https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.
 
 ===== Implementation
 
-Currently, implementation from <<Get,`Get`>> is reused.
+For `ONCE`, `POLL` and first `STREAM` response, the implementation from <<Get,`Get`>> is reused.
+Changes for `STREAM` subscription are collected as they occur and are sent as response.
+
+Current implementation can be described with help of following diagrams.
+
+====== ONCE Subscription diagram
+
+ifdef::env-github[]
+image::{gitplant-develop}/subscribe_once.puml[]
+endif::[]
+ifndef::env-github[]
+plantuml::subscribe_once.puml[format="svg", align="center"]
+endif::[]
+
+
+====== POLL Subscription diagram
+
+ifdef::env-github[]
+image::{gitplant-develop}/subscribe_poll.puml[]
+endif::[]
+ifndef::env-github[]
+plantuml::subscribe_poll.puml[format="svg", align="center"]
+endif::[]
+
+====== STREAM Subscription diagram
+
+ifdef::env-github[]
+image::{gitplant-develop}/subscribe_stream.puml[]
+endif::[]
+ifndef::env-github[]
+plantuml::subscribe_stream.puml[format="svg", align="center"]
+endif::[]
+
 
 ===== TODO
 
 * see <<Get, Get TODO>>
-* only `ONCE` and `POLL` mode is supported
-* many parameters are not supported, see <<Limitations and TODOs>>.
+* several subscription parameters are not supported, see <<Limitations and TODOs>>.
 
 === Automated tests
 
@@ -613,7 +732,7 @@ NOTE: All gRPC API tests require ConfD running (`make start`)
 
 ==== Integration tests
 
-_Not yet implmented_.
+_Not yet implemented_.
 
 === Limitations and TODOs
 
@@ -624,15 +743,16 @@ This not all gNMI functionality are currently supported. They may be added in th
 *Limitations*
 
 * only `BYTES` are used as `encoding`
-* `Get`, `Set` and `Subscribe` works only on `leaf` and last `list` elements
+* `Get`, `Set` and `Subscribe` works only on `the leaf`, list` entries and `lists`
 * `Set` works only on `leaf` elements
 * `Subscribe`
-** only `ONCE` anf `POLL` subscription mode is supported
+** Not all subscription parameters are supported
 ** `updates_only` not supported
 ** `heartbeat_interval` not supported
 * * `sync_response` not generated
 * all values `TypedValues` are used as strings (`string_val`)
 * gNMI Path is converted to XPath or formatted path with simple string operations (no datamodel knowledge used)
+* only `lists` with one `key` are supported
 * current implementation works only against RUNNING DB
 * list of models (e.g. `Get`) is not supported
 * `leaf-lists` not supported

--- a/confdgnmi/docs/PumlGenerator.groovy
+++ b/confdgnmi/docs/PumlGenerator.groovy
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+/*
+  Install groovy and run this script `groovy UmlGenerator.groovy` to generate UML diagrams
+ */
+@Grab(group = 'net.sourceforge.plantuml', module = 'plantuml', version = '1.2021.2')
+@Grab(group = 'org.bitbucket.novakmi', module = 'nodebuilder', version = '1.1.1')
+@Grab(group = 'org.bitbucket.novakmi', module = 'plantumlbuilder', version = '1.0.0')
+import org.bitbucket.novakmi.plantumlbuilder.PlantUmlBuilder
+import org.bitbucket.novakmi.plantumlbuilder.PlantUmlBuilderCompPlugin
+import org.bitbucket.novakmi.plantumlbuilder.PlantUmlBuilderSeqPlugin
+
+class PumlGenerator {
+
+    static def makeBuilder() {
+        def builder = new PlantUmlBuilder()
+        builder.registerPlugin(new PlantUmlBuilderSeqPlugin())
+        // add extra support for Seq. diagrams
+        builder.registerPlugin(new PlantUmlBuilderCompPlugin())
+        // add extra support for component. diagrams
+        return builder
+    }
+
+    static def makeComponentHeader(builder) {
+        builder.plantuml {
+            UmlCommon.makeHeader(builder, 'ConfDGnmiAdapter interaction scenario', [skipList: [UmlCommon.user]])
+        }
+    }
+
+    static void main(String[] args) {
+        def builder = makeBuilder()
+        [
+                [fileName: 'subscribe_once', txt: true, fn: Subscriber.&makeSubscriberOnceSeq],
+                [fileName: 'subscribe_poll', txt: true, fn: Subscriber.&makeSubscriberPollSeq],
+                [fileName: 'subscribe_stream', txt: true, fn: Subscriber.&makeSubscriberStreamSeq],
+        ].each { it ->
+            builder.reset()
+            print "Processing  ${it.fileName}"
+            it.fn(builder)
+            def text = builder.getText()
+            if (it.txt) {
+                new File("./${it.fileName}.puml").write(text)
+            }
+            println " ... done."
+
+        }
+    }
+}

--- a/confdgnmi/docs/UmlCommon.groovy
+++ b/confdgnmi/docs/UmlCommon.groovy
@@ -1,0 +1,79 @@
+// This class contains reusable parts
+class UmlCommon {
+    public static def user = 'user'
+    public static def client = 'client'
+    public static def client_stub = 'Stub'
+    public static def sub_read = 'sub_read'
+    public static def server = 'server'
+    public static def adapter = 'adapter'
+    public static def device_adapter = 'device_adapter'
+    public static def device = 'device'
+    public static def arrowReturn = '-->'
+    public static def arrowBi = '<-->'
+
+    private static def colorBoxGnmi = '#FFEB99'
+    private static def colorBoxUser = '#Gold'
+    private static def colorBoxAdapter = '#E6F3F8'
+    private static def colorBoxDevice = '#FFEB99'
+
+    static def makeHeader(builder, text, params = null) {
+        builder.plant('hide footbox')
+        builder.autonumber()
+        builder.title(text)
+        makeSkin(builder)
+        makeParticipants(builder, params)
+    }
+
+    static def makeSkin(builder) {
+        // list of skinparams java -jar ~/.groovy/grapes/net.sourceforge.plantuml/plantuml/jars/plantuml-1.2017.18.jar -language
+        builder.plant("skinparam BackgroundColor #FFFFFF-#EEEBDC")
+        builder.plant("skinparam SequenceParticipantBackgroundColor #FFFFFF-#DDEBDC")
+        builder.plant("skinparam DatabaseBackgroundColor #FFFFFF-#DDEBDC")
+        builder.plant("skinparam SequenceBoxFontStyle plain")
+        builder.plant("skinparam SequenceGroupFontStyle plain")
+        builder.plant("skinparam SequenceDividerFontStyle plain")
+    }
+
+    static def makeParticipants(builder, params = null) {
+        def skipList = []
+
+        if (params) {
+            if (params?.skipList) {
+                skipList = params.skipList
+            }
+        }
+
+        if (!skipList.contains(user)) {
+            builder.box("              <size:40><&person></size> User                  ",
+                    color: colorBoxUser) {
+                actor(user)
+            }
+        }
+
+        builder.box("    gNMI Adapter client    ", color: colorBoxGnmi) {
+            if (!skipList.contains(client)) {
+                participant(client, as: '" <size:20><&terminal></size> gNMI Client "')
+            }
+            if (!skipList.contains(sub_read)) {
+                participant(sub_read, as: '"Subscription reader\\nthread "')
+            }
+
+        }
+        builder.box("    gNMI Adapter server     ", color: colorBoxAdapter) {
+            if (!skipList.contains(server)) {
+                participant(server, as: '" <size:20><&wrench></size> gNMI Server "')
+            }
+            if (!skipList.contains(adapter)) {
+                participant(adapter, as: '" <size:20><&list></size>  gNMI Adapter "')
+            }
+            if (!skipList.contains(device_adapter)) {
+                participant(device_adapter, as: '" <size:20><&list></size>  gNMI Device Adapter\\n(ConfD Adapter) "')
+            }
+        }
+        builder.box("    Device     ", color: colorBoxDevice) {
+            if (!skipList.contains(device)) {
+                participant(device, as: '" <size:20><&tablet></size> ConfD\\n(device) "')
+            }
+        }
+    }
+}

--- a/confdgnmi/docs/component.puml
+++ b/confdgnmi/docs/component.puml
@@ -83,7 +83,7 @@ node "gNMI Adapter\nServer" {
     GnmiServerAdapter <-le- GnmiConfDApiServerAdapter
     GnmiServerAdapter <.up. GnmiNetconfServerAdapter
     ConfDgNMIServicer "1" *-- GnmiServerAdapter
-    GnmiServerAdapter "1" *-- SubscriptionHandler
+    GnmiServerAdapter "1..n" *-- SubscriptionHandler
 
     GnmiConfDApiServerAdapter <..> ConfD
     GnmiConfDApiServerAdapter.SubscriptionHandler <..> ConfD

--- a/confdgnmi/docs/component.puml
+++ b/confdgnmi/docs/component.puml
@@ -57,19 +57,24 @@ node "gNMI Adapter\nServer" {
     }
 
     abstract class SubscriptionHandler {
+        {abstract} get_sample()
+        {abstract) get_monitored_changes()
+        {abstract} start_monitoring()
+        {abstract} stop_monitoring()
+        {abstract} add_path_for_monitoring()
+        ---
         add_subscription_list()
-        {abstract} make_subscription_response()
+        sample()
+        changes()
         stop()
         read()
         poll()
     }
 
     class GnmiConfDApiServerAdapter.SubscriptionHandler {
-        make_subscription_response()
     }
 
     class GnmiDemoServerAdapter.SubscriptionHandler {
-        make_subscription_response()
     }
 
     SubscriptionHandler <-- GnmiConfDApiServerAdapter.SubscriptionHandler

--- a/confdgnmi/docs/subscribe_once.puml
+++ b/confdgnmi/docs/subscribe_once.puml
@@ -1,0 +1,64 @@
+@startuml
+hide footbox
+autonumber
+title ONCE subscription
+skinparam BackgroundColor #FFFFFF-#EEEBDC
+skinparam SequenceParticipantBackgroundColor #FFFFFF-#DDEBDC
+skinparam DatabaseBackgroundColor #FFFFFF-#DDEBDC
+skinparam SequenceBoxFontStyle plain
+skinparam SequenceGroupFontStyle plain
+skinparam SequenceDividerFontStyle plain
+box "    gNMI Adapter client    " #FFEB99
+  participant client as " <size:20><&terminal></size> gNMI Client "
+  participant sub_read as "Subscription reader\nthread "
+end box
+box "    gNMI Adapter server     " #E6F3F8
+  participant server as " <size:20><&wrench></size> gNMI Server "
+  participant adapter as " <size:20><&list></size>  gNMI Adapter "
+  participant device_adapter as " <size:20><&list></size>  gNMI Device Adapter\n(ConfD Adapter) "
+end box
+box "    Device     " #FFEB99
+  participant device as " <size:20><&tablet></size> ConfD\n(device) "
+end box
+== Subscription ==
+[-> client : <size:24><&person></size> ""subscribe""
+activate client
+  note right of client : Subscription invoked. Request iterator (""SubscribeRequest"") is sent to the server, response iterator (""SubscribeResponse"") is returned to the client.
+  client -> server : Subscribe(stream SubscribeRequest)
+  activate server
+  server --> client : stream SubscribeResponse
+  note right of client : The client starts reading responses in dedicated thread (""read_subscribe_responses"").
+  client -> sub_read : start thread\n""read_subscribe_responses(responseIterator)""
+  activate sub_read
+  sub_read -> sub_read : iterate over responseIterator
+  activate sub_read
+    server -> server : subscription processing
+    activate server
+      note right of client : The server gets next element from ""SubscribeRequest"" stream (calls ""next(request_iterator)"").
+      server -> client : next SubscribeRequest\n(""generate_subscriptions"")
+      activate client
+      client --> server : ""yield SubscribeRequest"" item
+      deactivate client
+      note right of client : The client uses ""generate_subscriptions"" generator function to return next ""SubscribeRequest"" in the stream.
+      server -> adapter : read
+      activate adapter
+        note right of server : Get current sample (all values).
+        adapter -> device_adapter : get_sample
+        activate device_adapter
+          device_adapter <--> device
+        device_adapter --> adapter
+        deactivate device_adapter
+      adapter --> server : current sample
+      server --> sub_read : SubscribeResponse\n(returned in response stream)
+        sub_read -> sub_read : process response
+        activate sub_read
+        deactivate sub_read
+    deactivate server
+  deactivate sub_read
+  deactivate server
+  deactivate adapter
+  sub_read --> client : end response thread
+  deactivate sub_read
+[<-- client
+deactivate client
+@enduml

--- a/confdgnmi/docs/subscribe_poll.puml
+++ b/confdgnmi/docs/subscribe_poll.puml
@@ -1,0 +1,94 @@
+@startuml
+hide footbox
+autonumber
+title POLL subscription
+skinparam BackgroundColor #FFFFFF-#EEEBDC
+skinparam SequenceParticipantBackgroundColor #FFFFFF-#DDEBDC
+skinparam DatabaseBackgroundColor #FFFFFF-#DDEBDC
+skinparam SequenceBoxFontStyle plain
+skinparam SequenceGroupFontStyle plain
+skinparam SequenceDividerFontStyle plain
+box "    gNMI Adapter client    " #FFEB99
+  participant client as " <size:20><&terminal></size> gNMI Client "
+  participant sub_read as "Subscription reader\nthread "
+end box
+box "    gNMI Adapter server     " #E6F3F8
+  participant server as " <size:20><&wrench></size> gNMI Server "
+  participant adapter as " <size:20><&list></size>  gNMI Adapter "
+  participant device_adapter as " <size:20><&list></size>  gNMI Device Adapter\n(ConfD Adapter) "
+end box
+box "    Device     " #FFEB99
+  participant device as " <size:20><&tablet></size> ConfD\n(device) "
+end box
+== Subscription ==
+[-> client : <size:24><&person></size> ""subscribe""
+activate client
+  note right of client : Subscription invoked. Request iterator (""SubscribeRequest"") is sent to the server, response iterator (""SubscribeResponse"") is returned to the client.
+  client -> server : Subscribe(stream SubscribeRequest)
+  activate server
+  server --> client : stream SubscribeResponse
+  note right of client : The client starts reading responses in dedicated thread (""read_subscribe_responses"").
+  client -> sub_read : start thread\n""read_subscribe_responses(responseIterator)""
+  activate sub_read
+  sub_read -> sub_read : iterate over responseIterator
+  activate sub_read
+    server -> server : subscription processing
+    activate server
+      note right of client : The server gets next element from ""SubscribeRequest"" stream (calls ""next(request_iterator)"").
+      server -> client : next SubscribeRequest\n(""generate_subscriptions"")
+      activate client
+      client --> server : ""yield SubscribeRequest"" item
+      deactivate client
+      note right of client : The client uses ""generate_subscriptions"" generator function to return next ""SubscribeRequest"" in the stream.
+      server -> adapter : read
+      activate adapter
+        note right of server : Get current sample (all values).
+        adapter -> device_adapter : get_sample
+        activate device_adapter
+          device_adapter <--> device
+        device_adapter --> adapter
+        deactivate device_adapter
+      adapter --> server : current sample
+      server --> sub_read : SubscribeResponse\n(returned in response stream)
+        sub_read -> sub_read : process response
+        activate sub_read
+        deactivate sub_read
+      loop ""poll_count"" times
+        note right of client : The server gets next element from ""SubscribeRequest"" stream (calls ""next(request_iterator)"").
+        server -> client : next SubscribeRequest\n(""generate_subscriptions"")
+        activate client
+        client --> server : ""yield SubscribeRequest"" item with ""poll"" element
+        deactivate client
+        note right of server : When ""poll"" request comes, get current values and return them in response stream.
+        server --> adapter : poll
+        adapter -> device_adapter : get_sample
+        activate device_adapter
+          device_adapter <--> device
+        device_adapter --> adapter
+        deactivate device_adapter
+        adapter --> server : current (poll) sample
+        server --> sub_read : SubscribeResponse\n(returned in response stream)
+          sub_read -> sub_read : process response
+          activate sub_read
+          deactivate sub_read
+      end
+    deactivate server
+  deactivate sub_read
+  deactivate server
+  note right of server : Client or Servewr stops Request/Response stream.
+  sub_read --> server : reading ended\n(""subscribe_rpc_done"")
+  activate server
+    server -> adapter : stop
+    activate adapter
+    adapter --> server
+    deactivate adapter
+  server --> sub_read
+  deactivate server
+  deactivate device_adapter
+  deactivate device_adapter
+  deactivate adapter
+  sub_read --> client : end response thread
+  deactivate sub_read
+[<-- client
+deactivate client
+@enduml

--- a/confdgnmi/docs/subscribe_stream.puml
+++ b/confdgnmi/docs/subscribe_stream.puml
@@ -1,0 +1,99 @@
+@startuml
+hide footbox
+autonumber
+title STREAM subscription
+skinparam BackgroundColor #FFFFFF-#EEEBDC
+skinparam SequenceParticipantBackgroundColor #FFFFFF-#DDEBDC
+skinparam DatabaseBackgroundColor #FFFFFF-#DDEBDC
+skinparam SequenceBoxFontStyle plain
+skinparam SequenceGroupFontStyle plain
+skinparam SequenceDividerFontStyle plain
+box "    gNMI Adapter client    " #FFEB99
+  participant client as " <size:20><&terminal></size> gNMI Client "
+  participant sub_read as "Subscription reader\nthread "
+end box
+box "    gNMI Adapter server     " #E6F3F8
+  participant server as " <size:20><&wrench></size> gNMI Server "
+  participant adapter as " <size:20><&list></size>  gNMI Adapter "
+  participant device_adapter as " <size:20><&list></size>  gNMI Device Adapter\n(ConfD Adapter) "
+end box
+box "    Device     " #FFEB99
+  participant device as " <size:20><&tablet></size> ConfD\n(device) "
+end box
+== Subscription ==
+[-> client : <size:24><&person></size> ""subscribe""
+activate client
+  note right of client : Subscription invoked. Request iterator (""SubscribeRequest"") is sent to the server, response iterator (""SubscribeResponse"") is returned to the client.
+  client -> server : Subscribe(stream SubscribeRequest)
+  activate server
+  server --> client : stream SubscribeResponse
+  note right of client : The client starts reading responses in dedicated thread (""read_subscribe_responses"").
+  client -> sub_read : start thread\n""read_subscribe_responses(responseIterator)""
+  activate sub_read
+  sub_read -> sub_read : iterate over responseIterator
+  activate sub_read
+    server -> server : subscription processing
+    activate server
+      note right of client : The server gets next element from ""SubscribeRequest"" stream (calls ""next(request_iterator)"").
+      server -> client : next SubscribeRequest\n(""generate_subscriptions"")
+      activate client
+      client --> server : ""yield SubscribeRequest"" item
+      deactivate client
+      note right of client : The client uses ""generate_subscriptions"" generator function to return next ""SubscribeRequest"" in the stream.
+      server -> adapter : read
+      activate adapter
+        note right of server : Get current sample (all values).
+        adapter -> device_adapter : get_sample
+        activate device_adapter
+          device_adapter <--> device
+        device_adapter --> adapter
+        deactivate device_adapter
+        adapter -> device_adapter : start_monitoring
+        activate device_adapter
+        device_adapter --> adapter
+        device_adapter -> device_adapter : monitoring thread
+        activate device_adapter
+      adapter --> server : current sample
+      server --> sub_read : SubscribeResponse\n(returned in response stream)
+        sub_read -> sub_read : process response
+        activate sub_read
+        deactivate sub_read
+      loop ""read_count - 1 "" times
+        note left of device_adapter : Send message that changes are available.
+        device_adapter --> adapter : SEND_CHANGES
+        note right of adapter : get changes
+        adapter -> device_adapter : get_monitored_changes
+        activate device_adapter
+        device_adapter --> adapter
+        deactivate device_adapter
+        adapter --> server : current changes
+        note right of server : return changes in the response stream
+        server --> sub_read : SubscribeResponse\n(returned in response stream)
+          sub_read -> sub_read : process response
+          activate sub_read
+          deactivate sub_read
+      end
+    deactivate server
+  deactivate sub_read
+  deactivate server
+  note right of server : Client or Servewr stops Request/Response stream.
+  sub_read --> server : reading ended\n(""subscribe_rpc_done"")
+  activate server
+    server -> adapter : stop
+    activate adapter
+      adapter -> device_adapter : stop_monitoring
+      activate device_adapter
+      device_adapter --> adapter
+      deactivate device_adapter
+    adapter --> server
+    deactivate adapter
+  server --> sub_read
+  deactivate server
+  deactivate device_adapter
+  deactivate device_adapter
+  deactivate adapter
+  sub_read --> client : end response thread
+  deactivate sub_read
+[<-- client
+deactivate client
+@enduml

--- a/confdgnmi/src/confd_gnmi_api_adapter.py
+++ b/confdgnmi/src/confd_gnmi_api_adapter.py
@@ -1,11 +1,15 @@
+import os
+import select
 import sys
+import threading
 import xml.etree.ElementTree as ET
-from socket import socket
+from socket import socket, AF_INET, SOCK_STREAM
 
 import _confd
 # TODO replace maapi_low with high level MAAPI
 from _confd import maapi as maapi_low
 from confd import maapi, maagic
+from confd.cdb import cdb
 
 from confd_gnmi_adapter import GnmiServerAdapter
 from confd_gnmi_common import *
@@ -59,32 +63,183 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
 
     class SubscriptionHandler(GnmiServerAdapter.SubscriptionHandler):
 
-        def make_subscription_response(self) -> gnmi_pb2.SubscribeResponse:
-            log.debug("==>")
-            assert self.subscription_list != None
-            # for now we only process GET type (fetch and return everything)
-            assert self.subscription_stream_event_type == self.SubscriptionStreamEventType.GET
+        def __init__(self, adapter, subscription_list):
+            super().__init__(adapter, subscription_list)
+            # TODO reuse with demo adapter?
+            self.monitored_paths = []
+            self.change_db = []
+            self.change_db_lock = threading.Lock()
+            self.change_thread = None
+            self.stop_pipe = None
 
+        def get_monitored_changes(self) -> []:
+            # TODO reuse with demo adapter ?
+            self.change_db_lock.acquire()
+            log.debug("==> self.change_db=%s", self.change_db)
+            assert len(self.change_db) > 0
             update = []
-            for s in self.subscription_list.subscription:
-                update.extend(self.adapter.get_updates_with_maapi_save(s.path,
-                                                                       self.subscription_list.prefix,
-                                                                       gnmi_pb2.GetRequest.DataType.ALL))
-            # TODO delete
-            delete = []
-            notif = gnmi_pb2.Notification(timestamp=0,
-                                          prefix=self.subscription_list.prefix,
-                                          alias="/alias", update=update,
-                                          delete=delete,
-                                          atomic=False)
+            for c in self.change_db:
+                prefix_str = make_xpath_path(
+                    gnmi_prefix=self.subscription_list.prefix)
+                p = c[0]
+                if c[0].startswith(prefix_str):
+                    p = c[0][len(prefix_str):]
+                update.append(gnmi_pb2.Update(path=make_gnmi_path(p),
+                                              val=gnmi_pb2.TypedValue(
+                                                  string_val=c[1])))
+            self.change_db = []
+            self.change_db_lock.release()
+            log.debug("<== update=%s", update)
+            return update
 
-            response = gnmi_pb2.SubscribeResponse(update=notif)
-            log.debug("<== response=%s", response)
-            return response
+        def get_sample(self, path, prefix,
+                       start_change_processing=False):
+            update = []
+            log.debug("==>")
+            update.extend(self.adapter.get_updates_with_maapi_save(path,
+                                                                   prefix,
+                                                                   gnmi_pb2.GetRequest.DataType.ALL))
+            log.debug("<== update=%s", update)
+            return update
 
-    def get_subscription_handler(self) -> SubscriptionHandler:
+        def add_path_for_monitoring(self, path, prefix):
+            log.debug("==>")
+            path_with_prefix_str = make_formatted_path(path, prefix)
+            self.monitored_paths.append(path_with_prefix_str)
+            log.debug("<==")
+
+        def kp_to_xpath(self, kp):
+            log.debug("==> kp=%s", kp)
+            xpath = _confd.xpath_pp_kpath(kp)
+            xpath = xpath.replace('"', '')
+            # for now, remove possible prefix
+            starts_slash = xpath.startswith('/')
+            xplist = xpath.split(':', 1)
+            if len(xplist) == 2:
+                xpath = xplist[1]
+                if starts_slash:
+                    xpath = '/' + xpath
+            log.debug("<== xpath=%s", xpath)
+            return xpath
+
+        def process_subscription(self, sub_sock, sub_point):
+            log.debug("==>")
+
+            def iter(kp, op, oldv, newv, state):
+                log.debug("==> kp=%s, op=%r, oldv=%s, newv=%s, state=%r", kp,
+                          op, oldv, newv, state)
+                if op == _confd.MOP_CREATED:
+                    log.debug("_confd.MOP_CREATED")
+                    # TODO CREATE not handled for now
+                if op == _confd.MOP_VALUE_SET:
+                    log.debug("_confd.MOP_VALUE_SET")
+                    self.change_db_lock.acquire()
+                    xpath = self.kp_to_xpath(kp)
+                    self.change_db.append((xpath, str(newv)))
+                    self.change_db_lock.release()
+                    # TODO MOP_VALUE_SET implement
+                elif op == _confd.MOP_DELETED:
+                    log.debug("_confd.MOP_DELETED")
+                    # TODO DELETE not handled for now
+                elif op == _confd.MOP_MODIFIED:
+                    log.debug("_confd.MOP_MODIFIED")
+                    # TODO MODIFIED not handled for now
+                else:
+                    log.warning(
+                        "Operation op=%d is not expected, kp=%s. Skipping!"
+                        , op, kp)
+                return _confd.ITER_RECURSE
+
+            cdb.diff_iterate(sub_sock, sub_point, iter, 0, None)
+            self.put_event(self.SubscriptionEvent.SEND_CHANGES)
+            log.debug("self.change_db=%s", self.change_db)
+            log.debug("<==")
+
+        def process_changes(self):
+            log.debug("==>")
+            # make subscription for all self.monitored_paths
+            sub_sock = socket(AF_INET, SOCK_STREAM, 0)
+            prio = 10
+
+            cdb.connect(sub_sock, cdb.SUBSCRIPTION_SOCKET, '127.0.0.1',
+                        _confd.CONFD_PORT)
+            for p in self.monitored_paths:
+                log.debug("subscribing config p=%s", p)
+                # TODO hash - breaks generic usage
+                # TODO for now we subscribe path for both, config and oper,
+                # TODO subscribe only for paths that exist
+                # it may be more efficient to find out type of path and subscribe
+                # only for one type
+                cdb.subscribe2(sub_sock, cdb.SUB_RUNNING, 0, prio,
+                               0, p)
+                log.debug("subscribing operational p=%s", p)
+                cdb.subscribe2(sub_sock, cdb.SUB_OPERATIONAL, 0, prio,
+                               0, p)
+            cdb.subscribe_done(sub_sock)
+            log.debug("subscribe_done")
+            assert self.stop_pipe is not None
+            _r = [sub_sock, self.stop_pipe[0]]
+            _w = []
+            _e = []
+            try:
+                while True:
+                    log.debug("_r=%s", _r)
+                    r, w, e = select.select(_r, _w, _e)
+                    log.debug("r=%s", r)
+                    if self.stop_pipe[0] in r:
+                        v = os.read(self.stop_pipe[0], 1)
+                        assert v == b'x'
+                        log.debug("Stopping ConfD loop")
+                        break
+                    if sub_sock in r:
+                        try:
+                            list = cdb.read_subscription_socket2(sub_sock)
+                            for s in list[2]:
+                                self.process_subscription(sub_sock, s)
+                            cdb.sync_subscription_socket(sub_sock,
+                                                         cdb.DONE_PRIORITY)
+                        except _confd.error.Error as e:
+                            # Callback error
+                            if e.confd_errno is _confd.ERR_EXTERNAL:
+                                log.exception(e)
+                            else:
+                                raise e
+
+            except Exception as e:
+                log.exception(e)
+
+            log.debug("<==")
+
+        def start_monitoring(self):
+            log.debug("==>")
+            assert self.change_thread is None
+            assert self.stop_pipe is None
+            log.debug("** creating change_thread")
+            self.stop_pipe = os.pipe()
+            self.change_thread = threading.Thread(target=self.process_changes)
+            log.debug("** starting change_thread")
+            self.change_thread.start()
+            log.debug("** change_thread started")
+            log.debug("<==")
+
+        def stop_monitoring(self):
+            log.debug("==>")
+            assert self.change_thread is not None
+            assert self.stop_pipe is not None
+            log.debug("** stopping change_thread")
+            # https://stackoverflow.com/a/4661284
+            os.write(self.stop_pipe[1], b'x')
+            self.change_thread.join()
+            log.debug("** change_thread joined")
+            self.change_thread = None
+            self.stop_pipe = None
+            self.monitored_paths = []
+            log.debug("<==")
+
+    def get_subscription_handler(self,
+                                 subscription_list) -> SubscriptionHandler:
         log.debug("==>")
-        handler = self.SubscriptionHandler(self)
+        handler = self.SubscriptionHandler(self, subscription_list)
         log.debug("<== handler=%s", handler)
         return handler
 
@@ -199,7 +354,8 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
         return save_str
 
     def get_xml_paths(self, elem, orig_path_str, parent_path_cand=""):
-        log.debug("==> elem=%s", elem)
+        log.debug("==> elem=%s orig_path_str=%s parent_path_cand=%s", elem,
+                  orig_path_str, parent_path_cand)
         path_vals = []
         # skip top level 'config' element
         if not (parent_path_cand == "" and
@@ -212,13 +368,13 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
             # in this way we can detect some (non list) paths incorrectly, we try to fix
             # by comparing original path
             if len(elem) > 1:
-                if elem[0].text != None:
+                if elem[0].text is not None:
                     parent_path_cand2 = parent_path_cand + "[{}={}]".format(
                         elem[0].tag.split("}")[-1],
                         elem[0].text)
                     if parent_path_cand2.startswith(
                             orig_path_str) or orig_path_str.startswith(
-                            parent_path_cand2):
+                        parent_path_cand2):
                         parent_path_cand = parent_path_cand2
 
             for e in elem:
@@ -227,13 +383,13 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
         else:
             # check if this is path for exact key
             keypath_cand = None
-            if elem.text != None:
+            if elem.text is not None:
                 val = elem.text.split(":")[-1]
                 path_list = parent_path_cand.split('/')
                 if len(path_list) >= 2:
                     keypath_cand = "/".join(path_list[:-1]) + "[{}={}]".format(
                         path_list[-1], val) + "/" + path_list[-1]
-                if keypath_cand != None and orig_path_str == keypath_cand:
+                if keypath_cand is not None and orig_path_str == keypath_cand:
                     path = keypath_cand
                     parent_path_cand = path
                 else:
@@ -281,11 +437,12 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
 
     def get(self, prefix, paths, data_type, use_models):
         log.info("==> prefix=%s, paths=%s, data_type=%s, use_models=%s",
-                 prefix, paths, data_type, use_models);
+                 prefix, paths, data_type, use_models)
         notifications = []
         update = []
         for path in paths:
-            update.extend(self.get_updates_with_maapi_save(path, prefix, data_type))
+            update.extend(
+                self.get_updates_with_maapi_save(path, prefix, data_type))
         notif = gnmi_pb2.Notification(timestamp=1, prefix=prefix,
                                       update=update,
                                       delete=[],
@@ -295,10 +452,8 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
         return notifications
 
     def set(self, prefix, path, val):
-        log.info("==> prefix=%s, path=%s, val=%s",
-                 prefix, path, val);
+        log.info("==> prefix=%s, path=%s, val=%s", prefix, path, val)
         path_str = make_formatted_path(path, prefix)
-        op = gnmi_pb2.UpdateResult.INVALID
         context = "maapi"
         groups = [self.username]
         if hasattr(val, "string_val"):

--- a/confdgnmi/src/confd_gnmi_client.py
+++ b/confdgnmi/src/confd_gnmi_client.py
@@ -198,7 +198,7 @@ if __name__ == '__main__':
     subscription_mode = get_sub_mode(opt.submode)
     poll_interval: float = opt.pollinterval
     poll_count: int = opt.pollcount
-    read_count = opt.readcount
+    read_count: int = opt.readcount
 
     log.debug("datatype=%s subscription_mode=%s poll_interval=%s "
               "poll_count=%s read_count=%s",
@@ -230,7 +230,7 @@ if __name__ == '__main__':
             ConfDgNMIClient.print_notification(n)
     elif opt.operation == "set":
         if len(paths) != len(vals):
-            log.warnig("len(paths) != len(vals); %i != %i", len(paths),
+            log.warning("len(paths) != len(vals); %i != %i", len(paths),
                        len(vals))
             print(
                 "Number of paths (--path) must be the same as number of vals (--val)!")

--- a/confdgnmi/src/confd_gnmi_client.py
+++ b/confdgnmi/src/confd_gnmi_client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import optparse
 import threading
+
 from time import sleep
 
 from confd_gnmi_common import *
@@ -12,7 +13,9 @@ log = logging.getLogger('confd_gnmi_client')
 class ConfDgNMIClient:
 
     def __init__(self, host=HOST, port=PORT,
-                 metadata=[('username', 'admin'), ('password', 'admin')]):
+                 metadata=None):
+        if metadata is None:
+            metadata = [('username', 'admin'), ('password', 'admin')]
         log.info("==> host=%s, port=%i, metadata-%s", host, port, metadata)
         channel = grpc.insecure_channel("{}:{}".format(host, port))
         grpc.channel_ready_future(channel).result(timeout=5)
@@ -22,7 +25,7 @@ class ConfDgNMIClient:
 
     def get_capabilities(self):
         log.info("==>")
-        request = gnmi__pb2.CapabilityRequest()
+        request = gnmi_pb2.CapabilityRequest()
         log.debug("Calling stub.Capabilities")
         response = self.stub.Capabilities(request, metadata=self.metadata)
         log.info("<== response.supported_models=%s", response.supported_models)
@@ -31,11 +34,16 @@ class ConfDgNMIClient:
     @staticmethod
     def make_subscription_list(prefix, paths, mode):
         log.debug("==> mode=%s", mode)
-        qos = gnmi__pb2.QOSMarking(marking=1)
+        qos = gnmi_pb2.QOSMarking(marking=1)
         subscriptions = []
         for path in paths:
-            subscriptions.append(gnmi__pb2.Subscription(path=path))
-        subscription_list = gnmi__pb2.SubscriptionList(
+            if mode == gnmi_pb2.SubscriptionList.STREAM:
+                sub = gnmi_pb2.Subscription(path=path,
+                                            mode=gnmi_pb2.SubscriptionMode.ON_CHANGE)
+            else:
+                sub = gnmi_pb2.Subscription(path=path)
+            subscriptions.append(sub)
+        subscription_list = gnmi_pb2.SubscriptionList(
             prefix=prefix,
             subscription=subscriptions,
             use_aliases=False,
@@ -62,15 +70,15 @@ class ConfDgNMIClient:
                                poll_count=0):
         log.debug("==> subscription_list=%s", subscription_list)
 
-        sub = gnmi__pb2.SubscribeRequest(subscribe=subscription_list,
-                                         extension=[])
+        sub = gnmi_pb2.SubscribeRequest(subscribe=subscription_list,
+                                        extension=[])
         log.debug("subscription_list.mode=%s", subscription_list.mode)
         yield sub
 
         if subscription_list.mode == gnmi_pb2.SubscriptionList.POLL:
             for i in range(poll_count):
                 sleep(poll_interval)
-                print("Generating POLL subscription")
+                log.debug("Generating POLL subscription")
                 yield ConfDgNMIClient.make_poll_subscription()
 
         log.debug("<==")
@@ -86,39 +94,47 @@ class ConfDgNMIClient:
             print("path: {} value {}".format(make_xpath_path(u.path), u.val))
 
     @staticmethod
-    def read_subscribe_responses(responses):
-        log.info("==>")
+    def read_subscribe_responses(responses, read_count=-1):
+        log.info("==> read_count=%s", read_count)
         # example to cancel
         # responses.cancel()
         for response in responses:
-            log.info("******* Subscription received response=%s", response)
-            print("subscribe - response")
+            log.info("******* Subscription received response=%s read_count=%i", response, read_count)
+            print("subscribe - response read_count={}".format(read_count))
             ConfDgNMIClient.print_notification(response.update)
+            if read_count > 0:
+                read_count -= 1
+                if read_count == 0:
+                    break
+        log.info("Canceling read")
+        # See https://stackoverflow.com/questions/54588382/how-can-a-grpc-server-notice-that-the-client-has-cancelled-a-server-side-streami
+        responses.cancel()
 
         log.info("<==")
 
     # TODO this API would change with more subscription support
     def subscribe(self, subscription_list, read_thread=None,
-                  poll_interval=0, poll_count=0):
+                  poll_interval=0, poll_count=0, read_count=-1):
         log.info("==>")
         responses = self.stub.Subscribe(
             ConfDgNMIClient.generate_subscriptions(subscription_list,
                                                    poll_interval, poll_count),
             metadata=self.metadata)
         if read_thread is not None:
-            thr = threading.Thread(target=read_thread, args=(responses,))
+            thr = threading.Thread(target=read_thread,
+                                   args=(responses, read_count,))
             thr.start()
             thr.join()
         log.info("<== responses=%s", responses)
         return responses
 
-    def get(self, prefix, paths, type, encoding):
+    def get(self, prefix, paths, get_type, encoding):
         log.info("==>")
         path = []
         for p in paths:
             path.append(p)
         request = gnmi_pb2.GetRequest(prefix=prefix, path=path,
-                                      type=type,
+                                      type=get_type,
                                       encoding=encoding,
                                       extension=[])
         response = self.stub.Get(request, metadata=self.metadata)
@@ -156,29 +172,39 @@ if __name__ == '__main__':
     parser.add_option("-v", "--val", action="append", dest="vals",
                       help="'value' for set operation, can be repeated (empty by default)",
                       default=[])
+    parser.add_option("-s", "--sub-mode", action="store", dest="submode",
+                      help="subscription mode, can be ONCE, POLL, STREAM (default 'ONCE')",
+                      default="ONCE")
+    parser.add_option("--poll-count", action="store", dest="pollcount", type=int,
+                      help="Number of POLLs (default 5)",
+                      default=5)
+    parser.add_option("--poll-interval", action="store", dest="pollinterval", type=float,
+                      help="Interval (in seconds) between POLL requests (default 0.5)",
+                      default=0.5)
+    parser.add_option("--read-count", action="store", dest="readcount", type=int,
+                      help="Number of read requests for STREAM subscription (default 4)",
+                      default=4)
+
     (opt, args) = parser.parse_args()
     common_optparse_process(opt, log)
-
+    log.debug("opt=%s", opt)
     log.info("paths=%s vals=%s", opt.paths, opt.vals)
     prefix_str = opt.prefix
     prefix = make_gnmi_path(prefix_str)
     paths = [make_gnmi_path(p) for p in opt.paths]
     vals = [gnmi_pb2.TypedValue(string_val=v) for v in opt.vals]
 
-    datatype_map = {
-        "ALL": gnmi_pb2.GetRequest.DataType.ALL,
-        "CONFIG": gnmi_pb2.GetRequest.DataType.CONFIG,
-        "STATE": gnmi_pb2.GetRequest.DataType.STATE,
-        "OPERATIONAL": gnmi_pb2.GetRequest.DataType.OPERATIONAL,
-    }
-    datatype = datatype_map[opt.datatype]
+    datatype = get_data_type(opt.datatype)
+    subscription_mode = get_sub_mode(opt.submode)
+    poll_interval: float = opt.pollinterval
+    poll_count: int = opt.pollcount
+    read_count = opt.readcount
+
+    log.debug("datatype=%s subscription_mode=%s poll_interval=%s "
+              "poll_count=%s read_count=%s",
+              datatype, subscription_mode, poll_interval, poll_count, read_count)
 
     encoding = gnmi_pb2.Encoding.BYTES
-    subscription_mode = gnmi_pb2.SubscriptionList.POLL
-
-    poll_interval: int = 3
-    poll_count: int = 10
-    key = 82
     subscription_list = ConfDgNMIClient.make_subscription_list(
         prefix, paths, subscription_mode)
 
@@ -194,7 +220,8 @@ if __name__ == '__main__':
         print("Starting subscription ....")
         client.subscribe(subscription_list,
                          read_thread=ConfDgNMIClient.read_subscribe_responses,
-                         poll_interval=poll_interval, poll_count=poll_count)
+                         poll_interval=poll_interval, poll_count=poll_count,
+                         read_count=read_count)
         print(".... subscription done")
     elif opt.operation == "get":
         notification = client.get(prefix, paths, datatype, encoding)
@@ -203,7 +230,7 @@ if __name__ == '__main__':
             ConfDgNMIClient.print_notification(n)
     elif opt.operation == "set":
         if len(paths) != len(vals):
-            log.waring("len(paths) != len(vals); %i != %i", len(paths),
+            log.warnig("len(paths) != len(vals); %i != %i", len(paths),
                        len(vals))
             print(
                 "Number of paths (--path) must be the same as number of vals (--val)!")
@@ -213,10 +240,10 @@ if __name__ == '__main__':
             print("timestamp {} prefix {}".format(response.timestamp,
                                                   make_xpath_path(
                                                       response.prefix)))
-        for r in response.response:
-            print("timestamp {} op {} path {}".format(r.timestamp,
-                                                      r.op,
-                                                      make_xpath_path(
-                                                          r.path)))
+            for r in response.response:
+                print("timestamp {} op {} path {}".format(r.timestamp,
+                                                          r.op,
+                                                          make_xpath_path(
+                                                              r.path)))
     else:
         log.warning("Unknown operation %s", opt.operation)

--- a/confdgnmi/src/confd_gnmi_common.py
+++ b/confdgnmi/src/confd_gnmi_common.py
@@ -2,11 +2,11 @@ import logging
 
 import gnmi_pb2
 
-VERSION = "0.0.2"
+VERSION = "0.1.0"
 HOST = "localhost"
 PORT = 50061
 logging.basicConfig(
-    format='%(asctime)s:%(relativeCreated)s %(levelname)s:%(filename)s:%(lineno)s:%(funcName)s %(message)s',
+    format='%(asctime)s:%(relativeCreated)s %(levelname)s:%(filename)s:%(lineno)s:%(funcName)s %(message)s [%(threadName)s]',
     level=logging.WARNING)
 log = logging.getLogger('confd_gnmi_common')
 
@@ -29,6 +29,10 @@ def common_optparse_process(opt, log):
         level = logging.DEBUG
     else:
         log.warning("Unknown logging level %s", opt.logging)
+    set_logging_level(level)
+
+
+def set_logging_level(level):
     if level is not None:
         # Thanks https://stackoverflow.com/a/53250066
         [logging.getLogger(name).setLevel(level) for name in
@@ -54,7 +58,7 @@ def make_name_keys(elem_string) -> (str, str):
                 key = k.replace("]", '').split('=')
                 keys[key[0]] = key[1]
     log.debug("<== name=%s keys=%s", name, keys)
-    return (name, keys)
+    return name, keys
 
 
 # Crate gNMI Path object from string representation of path
@@ -152,3 +156,22 @@ def make_formatted_path(gnmi_path, gnmi_prefix=None, quote_val=False) -> str:
 
     log.debug("<== path_str=%s", path_str)
     return path_str
+
+
+def get_data_type(datatype_str):
+    datatype_map = {
+        "ALL": gnmi_pb2.GetRequest.DataType.ALL,
+        "CONFIG": gnmi_pb2.GetRequest.DataType.CONFIG,
+        "STATE": gnmi_pb2.GetRequest.DataType.STATE,
+        "OPERATIONAL": gnmi_pb2.GetRequest.DataType.OPERATIONAL,
+    }
+    return datatype_map[datatype_str]
+
+
+def get_sub_mode(mode_str):
+    mode_map = {
+        "ONCE":gnmi_pb2.SubscriptionList.ONCE,
+        "POLL": gnmi_pb2.SubscriptionList.POLL,
+        "STREAM": gnmi_pb2.SubscriptionList.STREAM,
+    }
+    return mode_map[mode_str]

--- a/confdgnmi/src/confd_gnmi_demo_adapter.py
+++ b/confdgnmi/src/confd_gnmi_demo_adapter.py
@@ -1,3 +1,10 @@
+import random
+import threading
+import xml.etree.ElementTree as ET
+from enum import Enum
+from queue import Queue, Empty
+from random import randint
+
 from confd_gnmi_adapter import GnmiServerAdapter
 from confd_gnmi_common import *
 
@@ -9,17 +16,55 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
     # map with XPath, value - both strings
     demo_db = {}
     demo_state_db = {}
+    # we use same lock for demo_db and demo_state_db
+    db_lock = threading.Lock()
     num_of_ifs = 10
     _instance: GnmiServerAdapter = None
+    # config map of config elements
+    # "changes" - array of changes contains  (path, val)  tuples or "break"
+    #             or "send" string
+    # "changes_idx" - current index of processing of "changes" array
+    config = {}
 
     capability_list = [
-        dict(name="tailf-common", organization="", version="2020-06-25"),
+        dict(name="tailf-aaa", organization="", version="2018-09-12"),
         dict(name="ietf-inet-types", organization="", version="2013-07-15"),
         dict(name="ietf-interfaces", organization="", version="2014-05-08"),
     ]
 
     def __init__(self):
         self._fill_demo_db()
+
+    @staticmethod
+    def load_config_string(xml_cfg):
+        """
+        Load config from string
+        """
+        log.debug("==> cfg=%s", xml_cfg)
+        root = ET.fromstring(xml_cfg)
+        log.info("root=%s", root)
+        assert root.tag == "demo"
+        changes = root.findall("./subscription/STREAM/changes/element")
+        log.debug("changes=%s", changes)
+        if len(changes):
+            if "changes" not in GnmiDemoServerAdapter.config:
+                GnmiDemoServerAdapter.config["changes"] = []
+                GnmiDemoServerAdapter.config["changes_idx"] = 0
+            for el in changes:
+                log.debug("len(el)=%s", len(el))
+                if len(el):
+                    if len(el) == 2:
+                        path = el[0]
+                        val = el[1]
+                        log.debug("path.text=%s val.text=%s", path.text,
+                                  val.text)
+                        GnmiDemoServerAdapter.config["changes"].append(
+                            (path.text, val.text))
+                elif len(el) == 0:
+                    log.debug("el.tag=%s", el.text)
+                    GnmiDemoServerAdapter.config["changes"].append(el.text)
+        log.debug("<== GnmiDemoServerAdapter.config=%s",
+                  GnmiDemoServerAdapter.config)
 
     @classmethod
     def get_inst(cls):
@@ -29,6 +74,7 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
 
     def _fill_demo_db(self):
         log.debug("==>")
+        self.db_lock.acquire()
         for i in range(GnmiDemoServerAdapter.num_of_ifs):
             if_name = "if_{}".format(i + 1)
             state_if_name = "state_if_{}".format(i + 1)
@@ -39,50 +85,217 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
             self.demo_state_db["{}/name".format(state_path)] = state_if_name
             self.demo_db["{}/type".format(path)] = "gigabitEthernet"
             self.demo_state_db["{}/type".format(state_path)] = "gigabitEthernet"
+        self.db_lock.release()
         log.debug("<== self.demo_db=%s self.demo_state_db=%s", self.demo_db,
                   self.demo_state_db)
 
     class SubscriptionHandler(GnmiServerAdapter.SubscriptionHandler):
 
-        def make_subscription_response(self) -> gnmi_pb2.SubscribeResponse:
-            log.debug("==>")
-            assert self.subscription_list != None
-            # for now we only process GET type (fetch and return everything)
-            assert self.subscription_stream_event_type == self.SubscriptionStreamEventType.GET
+        class ChangeEvent(Enum):
+            ADD = 0
+            SEND = 1
+            FINISH = 10
 
+        def __init__(self, adapter, subscription_list):
+            super().__init__(adapter, subscription_list)
+            self.monitored_paths = []
+            self.change_db = []
+            self.change_db_lock = threading.Lock()
+            self.change_thread = None
+            self.change_event_queue = None
+
+        def get_sample(self, path, prefix) -> []:
+            log.debug("==>")
             update = []
-            for s in self.subscription_list.subscription:
-                path_with_prefix_str = make_xpath_path(s.path,
-                                                       self.subscription_list.prefix)
-                prefix_str = make_xpath_path(
-                    gnmi_prefix=self.subscription_list.prefix)
-                log.debug("path_with_prefix_str=%s perfix_str=%s",
-                          path_with_prefix_str, prefix_str)
-                for p, v in self.adapter.demo_db.items():
+            path_with_prefix_str = make_xpath_path(path, prefix)
+            prefix_str = make_xpath_path(gnmi_prefix=prefix)
+            log.debug("path_with_prefix_str=%s prefix_str=%s",
+                      path_with_prefix_str, prefix_str)
+
+            def get_updates(db):
+                for p, v in db.items():
                     if p.startswith(path_with_prefix_str):
                         p = p[len(prefix_str):]
                         update.append(gnmi_pb2.Update(path=make_gnmi_path(p),
                                                       val=gnmi_pb2.TypedValue(
                                                           string_val=v)))
-            delete = []
-            notif = gnmi_pb2.Notification(timestamp=0,
-                                          prefix=self.subscription_list.prefix,
-                                          alias="/alias", update=update,
-                                          delete=delete,
-                                          atomic=False)
 
-            response = gnmi_pb2.SubscribeResponse(update=notif)
-            log.debug("<== response=%s", response)
-            return response
+            self.adapter.db_lock.acquire()
+            get_updates(self.adapter.demo_db)
+            # 'if' below is optimization
+            if len(update) == 0:
+                get_updates(self.adapter.demo_state_db)
+            self.adapter.db_lock.release()
 
-    def get_subscription_handler(self) -> SubscriptionHandler:
+            log.debug("<== update=%s", update)
+            return update
+
+        def get_monitored_changes(self) -> []:
+            self.change_db_lock.acquire()
+            log.debug("==> self.change_db=%s", self.change_db)
+            assert len(self.change_db) > 0
+            update = []
+            for c in self.change_db:
+                prefix_str = make_xpath_path(
+                    gnmi_prefix=self.subscription_list.prefix)
+                p = c[0]
+                if c[0].startswith(prefix_str):
+                    p = c[0][len(prefix_str):]
+                update.append(gnmi_pb2.Update(path=make_gnmi_path(p),
+                                              val=gnmi_pb2.TypedValue(
+                                                  string_val=c[1])))
+            self.change_db = []
+            self.change_db_lock.release()
+            log.debug("<== update=%s", update)
+            return update
+
+        def _get_random_changes(self):
+            log.debug("==>")
+            changes = []
+            candidate_paths = set()
+            for mp in self.monitored_paths:
+                for p, v in self.adapter.demo_db.items():
+                    if p.startswith(mp):
+                        # we only simulate changes on type leaf
+                        candidate_paths.add(
+                            p.replace("/name", "/type"))
+            log.debug("candidate_paths=%s", candidate_paths)
+            for path in random.sample(candidate_paths,
+                                      min(len(candidate_paths), 4)):
+                new_val = "gigabitEthernet"
+                if self.adapter.demo_db[path] == "gigabitEthernet":
+                    new_val = "fastEther"
+                log.debug("adding change path=%s, new_val=%s", path,
+                          new_val)
+                changes.append((path, new_val))
+            if randint(0, 9) < 8:
+                changes.append("send")
+            else:
+                changes.append("break")
+            log.debug("<== changes=%s", changes)
+            return changes
+
+        @staticmethod
+        def _get_config_changes():
+            log.debug("==>")
+            assert "changes_idx" in GnmiDemoServerAdapter.config
+            assert "changes" in GnmiDemoServerAdapter.config
+            changes = []
+            idx = GnmiDemoServerAdapter.config["changes_idx"]
+            if idx >= len(GnmiDemoServerAdapter.config["changes"]):
+                idx = 0
+            while idx < len(GnmiDemoServerAdapter.config["changes"]):
+                c = GnmiDemoServerAdapter.config["changes"][idx]
+                changes.append(c)
+                idx += 1
+                if isinstance(c, str):
+                    break
+            GnmiDemoServerAdapter.config["changes_idx"] = idx
+            log.debug("<== changes=%s", changes)
+            return changes
+
+        def process_changes(self):
+            log.debug("==>")
+            add_count = 0
+            # there may be more changes to same path, we cannot use map
+            assert self.change_event_queue is not None
+            assert len(self.change_db) == 0
+            while True:
+                try:
+                    log.debug("getting event")
+                    event = self.change_event_queue.get(timeout=1)
+                    log.debug("event=%s", event)
+                    if event == self.ChangeEvent.ADD:
+                        # generate modifications and add them
+                        self.change_db_lock.acquire()
+                        self.adapter.db_lock.acquire()
+                        if "changes" in GnmiDemoServerAdapter.config:
+                            changes = self._get_config_changes()
+                        else:
+                            changes = self._get_random_changes()
+                        send = False
+                        for c in changes:
+                            log.debug("processing change c=%s", c)
+                            if isinstance(c, str):
+                                assert c == "send" or c == "break"
+                                if c == "send":
+                                    send = True
+                                break
+                            else:
+                                log.info("c=%s self.monitored_paths=%s", c, self.monitored_paths)
+                                if any(c[0].startswith(elem) for elem in
+                                       self.monitored_paths):
+                                    log.info("appending c=%s", c)
+                                    self.change_db.append(c)
+                                    if c[0] in self.adapter.demo_db:
+                                        self.adapter.demo_db[c[0]] = c[1]
+                                    elif c[0] in self.adapter.demo_state_db:
+                                        self.adapter.demo_state_db[c[0]] = c[1]
+                                    else:
+                                        assert False
+                        self.adapter.db_lock.release()
+                        self.change_db_lock.release()
+                        if send:
+                            if len(self.change_db):
+                                self.change_event_queue.put(self.ChangeEvent.SEND)
+                    elif event == self.ChangeEvent.SEND:
+                        # send all modified paths
+                        self.put_event(self.SubscriptionEvent.SEND_CHANGES)
+                    elif event == self.ChangeEvent.FINISH:
+                        break
+                    else:
+                        log.warning("Unknown change processing event %s", event)
+                except Empty:
+                    # if we get timeout, let's add some modifications
+                    log.debug("Empty timeout")
+                    if add_count == 0:
+                        add_count += 1
+                        # sometimes skip add if is first from previous
+                        if randint(0, 1) == 0:
+                            continue
+                    add_count = 0  # reset add count
+                    self.change_event_queue.put(self.ChangeEvent.ADD)
+            log.debug("<==")
+
+        def add_path_for_monitoring(self, path, prefix):
+            log.debug("==>")
+
+            if self.change_event_queue is None:
+                self.change_event_queue = Queue()
+            path_with_prefix_str = make_xpath_path(path, prefix)
+            self.monitored_paths.append(path_with_prefix_str)
+            log.debug("<==")
+
+        def start_monitoring(self):
+            log.debug("==>")
+            assert self.change_thread is None
+            log.debug("** creating change_thread")
+            self.change_thread = threading.Thread(
+                target=self.process_changes)
+            log.debug("** starting change_thread")
+            self.change_thread.start()
+            log.debug("** change_thread started")
+            log.debug("<==")
+
+        def stop_monitoring(self):
+            log.debug("==>")
+            assert self.change_thread is not None
+            log.debug("** stopping change_thread")
+            self.change_event_queue.put(self.ChangeEvent.FINISH)
+            self.change_thread.join()
+            log.debug("** change_thread joined")
+            assert self.change_event_queue.empty()
+            self.change_thread = None
+            self.change_event_queue = None
+            self.monitored_paths = []
+            log.debug("<==")
+
+    def get_subscription_handler(self,
+                                 subscription_list) -> SubscriptionHandler:
         log.debug("==>")
-        handler = self.SubscriptionHandler(self)
+        handler = self.SubscriptionHandler(self, subscription_list)
         log.debug("<== handler=%s", handler)
         return handler
-
-    def get_instance(cls) -> GnmiServerAdapter:
-        return GnmiDemoServerAdapter()
 
     def capabilities(self):
         cap = []
@@ -99,7 +312,7 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
         path_with_prefix_str = make_xpath_path(gnmi_path=path,
                                                gnmi_prefix=prefix)
         prefix_str = make_xpath_path(gnmi_prefix=prefix)
-        log.debug("path_with_prefix_str=%s perfix_str=%s",
+        log.debug("path_with_prefix_str=%s prefix_str=%s",
                   path_with_prefix_str, prefix_str)
         update = []
 
@@ -111,17 +324,19 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
                                                   val=gnmi_pb2.TypedValue(
                                                       string_val=v)))
 
+        self.db_lock.acquire()
         if data_type == gnmi_pb2.GetRequest.DataType.CONFIG or \
                 data_type == gnmi_pb2.GetRequest.DataType.ALL:
             process_db(self.demo_db)
         if data_type != gnmi_pb2.GetRequest.DataType.CONFIG:
             process_db(self.demo_state_db)
+        self.db_lock.release()
         log.debug("<== update=%s", update)
         return update
 
     def get(self, prefix, paths, data_type, use_models):
         log.debug("==> prefix=%s, paths=%s, data_type=%s, use_models=%s",
-                  prefix, paths, data_type, use_models);
+                  prefix, paths, data_type, use_models)
         notifications = []
         update = []
         for path in paths:
@@ -135,8 +350,7 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
         return notifications
 
     def set(self, prefix, path, val):
-        log.info("==> prefix=%s, path=%s, val=%s",
-                 prefix, path, val);
+        log.info("==> prefix=%s, path=%s, val=%s", prefix, path, val)
         path_str = make_xpath_path(path, prefix)
         op = gnmi_pb2.UpdateResult.INVALID
         if path_str in self.demo_db:
@@ -145,7 +359,9 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
             else:
                 # TODO
                 str_val = "{}".format(val)
+            self.db_lock.acquire()
             self.demo_db[path_str] = str_val
+            self.db_lock.release()
             op = gnmi_pb2.UpdateResult.UPDATE
 
         log.info("==> op=%s", op)

--- a/confdgnmi/src/confd_gnmi_netconf_adapter.py
+++ b/confdgnmi/src/confd_gnmi_netconf_adapter.py
@@ -3,15 +3,18 @@ from confd_gnmi_adapter import GnmiServerAdapter
 
 class GnmiNetconfServerAdapter(GnmiServerAdapter):
 
-    def get_subscription_handler(self):
+    @classmethod
+    def get_inst(cls):
         pass
 
-    def get_instance(cls):
-        return GnmiNetconfServerAdapter()
+    def set(self, prefix, path, val):
+        pass
+
+    def get_subscription_handler(self, subscription_list):
+        pass
 
     def capabilities(self):
         return []
 
     def get(self, prefix, paths, data_type, use_models):
         return []
-

--- a/confdgnmi/src/confd_gnmi_server.py
+++ b/confdgnmi/src/confd_gnmi_server.py
@@ -205,9 +205,8 @@ class ConfDgNMIServicer(gNMIServicer):
         # `yield from` can be used, but to allow altering (e.g. path conversion)
         # response later on we use `for`
         for response in handler.read():
-            log.debug("response received")
+            log.debug("response received, calling yield")
             yield response
-            log.debug("response yield")
 
         if thr is not None:
             thr.join()

--- a/confdgnmi/src/confd_gnmi_server.py
+++ b/confdgnmi/src/confd_gnmi_server.py
@@ -25,17 +25,19 @@ class ConfDgNMIServicer(gNMIServicer):
         self.adapter_type = adapter_type
         assert isinstance(self.adapter_type, AdapterType)
 
-    def extract_user_metadata(self, context):
+    @staticmethod
+    def extract_user_metadata(context):
         log.debug("=>")
         log.debug("metadata=%s", context.invocation_metadata())
         metadict = dict(context.invocation_metadata())
         username = metadict["username"]
         password = metadict["password"]
         log.debug("<= username=%s password=:-)", username)
-        return (username, password)
+        return username, password
 
     def get_adapter(self):
         log.debug("==> self.adapter_type=%s", self.adapter_type)
+        adapter = None
         if self.adapter_type == AdapterType.DEMO:
             adapter = GnmiDemoServerAdapter.get_inst()
         elif self.adapter_type == AdapterType.API:
@@ -43,7 +45,8 @@ class ConfDgNMIServicer(gNMIServicer):
         log.debug("<== adapter=%s", adapter)
         return adapter
 
-    def connect_adapter(self, adapter, username, password):
+    @staticmethod
+    def connect_adapter(adapter, username, password):
         log.debug("==> adapter=%s username=%s password=:-)", adapter, username)
         if isinstance(adapter, GnmiConfDApiServerAdapter):
             adapter.connect(addr=GnmiConfDApiServerAdapter.confd_addr,
@@ -51,7 +54,8 @@ class ConfDgNMIServicer(gNMIServicer):
                             username=username, password=password)
         log.debug("<==")
 
-    def disconnect_adapter(self, adapter):
+    @staticmethod
+    def disconnect_adapter(adapter):
         if isinstance(adapter, GnmiConfDApiServerAdapter):
             adapter.disconnect()
 
@@ -103,8 +107,9 @@ class ConfDgNMIServicer(gNMIServicer):
         return response
 
     def Get(self, request, context):
-        """Retrieve a snapshot of data from the target. A Get RPC requests that the
-        target snapshots a subset of the data tree as specified by the paths
+        """
+        Retrieve a snapshot of data from the target. A Get RPC requests that
+        the target snapshots a subset of the data tree as specified by the paths
         included in the message and serializes this to be returned to the
         client using the specified encoding.
         Reference: gNMI Specification Section 3.3
@@ -143,6 +148,31 @@ class ConfDgNMIServicer(gNMIServicer):
         log.info("<== response=%s", response)
         return response
 
+    @staticmethod
+    def _read_sub_request(request_iterator, handler, stop_on_end=False):
+        log.debug("==> stop_on_end=%s", stop_on_end)
+        try:
+            for req in request_iterator:
+                # TODO check req mode is POLL
+                log.debug("req=%s", req)
+                if hasattr(req, "poll"):
+                    handler.poll()
+                elif hasattr(req, "alias"):
+                    # TODO exception, "alias: request not yet implemented
+                    assert False
+                else:
+                    # TODO exception, not expected other type of request
+                    assert False
+        except grpc.RpcError as e:
+            # check if this is end of Poll sending
+            if handler.is_poll():
+                log.exception(e)
+        log.debug("Request loop ended.")
+        if stop_on_end:
+            log.debug("stopping handler")
+            handler.stop()
+        log.debug("<==")
+
     def Subscribe(self, request_iterator, context):
         """Subscribe allows a client to request the target to send it values
         of particular paths within the data tree. These values may be streamed
@@ -153,38 +183,31 @@ class ConfDgNMIServicer(gNMIServicer):
         log.info(
             "==> request_iterator=%s context=%s", request_iterator, context)
 
-        def read_sub_request(request_iterator, handler):
-            for req in request_iterator:
-                # TODO check req mode is POLL
-                if hasattr(req, "poll"):
-                    handler.poll()
-                elif hasattr(req, "alias"):
-                    # TODO exception, "alias: request not yet implemented
-                    assert (False)
-                else:
-                    # TODO exception, not expected other type of request
-                    assert (False)
-            handler.stop()
+        def subscribe_rpc_done():
+            log.info("==>")
+            if not handler.is_once():
+                handler.stop()
+            log.info("<==")
 
-        adapter = self.get_connected_adapter(context)
-        handler = adapter.get_subscription_handler()
-        # first request, should contain subscription list (`subscribe`)
         request = next(request_iterator)
-        # TODO exception
+        adapter = self.get_connected_adapter(context)
+        context.add_callback(subscribe_rpc_done)
+        # first request, should contain subscription list (`subscribe`)
         assert hasattr(request, "subscribe")
-        handler.add_subscription_list(request.subscribe)
+        handler = adapter.get_subscription_handler(request.subscribe)
+
         thr = None
-        streaming = (
-                            request.subscribe.mode == gnmi_pb2.SubscriptionList.POLL) or (
-                            request.subscribe.mode == gnmi_pb2.SubscriptionList.STREAM)
-        if streaming:
-            thr = threading.Thread(target=read_sub_request,
-                                   args=(request_iterator, handler,))
+        if not handler.is_once():
+            thr = threading.Thread(target=ConfDgNMIServicer._read_sub_request,
+                                   args=(request_iterator, handler,
+                                         handler.is_poll()))
             thr.start()
         # `yield from` can be used, but to allow altering (e.g. path conversion)
         # response later on we use `for`
-        for response in handler.read(streaming=streaming):
+        for response in handler.read():
+            log.debug("response received")
             yield response
+            log.debug("response yield")
 
         if thr is not None:
             thr.join()
@@ -193,7 +216,7 @@ class ConfDgNMIServicer(gNMIServicer):
         log.info("<==")
 
     @staticmethod
-    def serve(port = PORT, adapter_type=AdapterType.DEMO):
+    def serve(port=PORT, adapter_type=AdapterType.DEMO):
         log.info("==> port=%s adapter_type=%s", port, adapter_type)
 
         server = grpc.server(ThreadPoolExecutor(max_workers=10))
@@ -221,6 +244,8 @@ if __name__ == '__main__':
                       help="ConfD port (default is {})".format(
                           GnmiConfDApiServerAdapter.confd_port),
                       default=GnmiConfDApiServerAdapter.confd_port)
+    parser.add_option("--cfg", action="store", dest="cfg",
+                      help="config file")
     (opt, args) = parser.parse_args()
     common_optparse_process(opt, log)
     adapter_type = AdapterType.DEMO
@@ -233,6 +258,12 @@ if __name__ == '__main__':
     #     adapter_type = AdapterType.NETCONF
     elif opt.type == "demo":
         adapter_type = AdapterType.DEMO
+        if opt.cfg:
+            log.info("processing config file opt.cfg=%s", opt.cfg)
+            with open(opt.cfg, "r") as cfg_file:
+                cfg = cfg_file.read()
+            log.debug("cfg=%s", cfg)
+            GnmiDemoServerAdapter.load_config_string(cfg)
     else:
         log.warning("Unknown server type %s", opt.type)
 

--- a/confdgnmi/test.sh
+++ b/confdgnmi/test.sh
@@ -4,4 +4,6 @@
 # ./test.sh -s -v -m unit tests
 # ./test.sh -s -v -m api tests
 # ./test.sh -s -v -m api -o log_cli=true tests
+# ./test.sh -o log_cli=true -s -v tests/test_client_server.py::TestGrpc::test_subscribe_stream -k AdapterType.API
+# ./test.sh -s -v --count=2 --repeat-scope session  tests #req. pytest-repeat plugin
 PYTHONPATH=./src:./tests:${PYTHONPATH} pytest "$@"

--- a/confdgnmi/tests/pytest.ini
+++ b/confdgnmi/tests/pytest.ini
@@ -6,3 +6,4 @@ markers =
     grpc: mark test as gRPC API test
     demo: mark test as testing with demo
     confd: mark test as testing with confd
+    long: mark test as long duration

--- a/confdgnmi/tests/test_client_server.py
+++ b/confdgnmi/tests/test_client_server.py
@@ -1,8 +1,13 @@
+import subprocess
+import threading
+import xml.etree.cElementTree as ET
+from time import sleep
+
 import pytest
 
 import gnmi_pb2
 from confd_gnmi_client import ConfDgNMIClient
-from confd_gnmi_common import make_gnmi_path
+from confd_gnmi_common import make_gnmi_path, get_data_type, make_formatted_path
 from confd_gnmi_demo_adapter import GnmiDemoServerAdapter
 from confd_gnmi_server import ConfDgNMIServicer, AdapterType
 from utils.utils import log, nodeid_to_path
@@ -27,6 +32,7 @@ class TestGrpc(object):
     @pytest.fixture
     def fix_method(self, request):
         log.debug("==> fixture method setup request={}".format(request))
+        # set_logging_level(logging.DEBUG)
         nodeid_path = nodeid_to_path(request.node.nodeid)
         log.debug("request.fixturenames=%s", request.fixturenames)
         if 'adapter_type' in request.fixturenames:
@@ -83,6 +89,7 @@ class TestGrpc(object):
 
     @staticmethod
     def assert_in_updates(updates, path_vals):
+        log.debug("==> updates=%s path_vals=%s", updates, path_vals)
         assert (len(updates) >= len(path_vals))
         for pv in path_vals:
             found = False
@@ -92,71 +99,146 @@ class TestGrpc(object):
                     found = True
                     break
             assert found
+        log.debug("<==")
 
-    def _test_get_subscribe_once(self, is_subscribe=False,
-                                 datatype=gnmi_pb2.GetRequest.DataType.CONFIG):
-        if_state_str = prefix_state_str= ""
+    def verify_get_response_updates(self, prefix, paths, path_value,
+                                    datatype, encoding, assert_fun=None):
+        if assert_fun is None:
+            assert_fun = TestGrpc.assert_updates
+        log.debug("prefix=%s paths=%s pv_list=%s datatype=%s encoding=%s",
+                  prefix, paths, path_value, datatype, encoding)
+        notification = self.client.get(prefix, paths, datatype, encoding)
+        log.debug("notification=%s", notification)
+        for n in notification:
+            log.debug("n=%s", n)
+            assert (n.prefix == prefix)
+            assert_fun(n.update, path_value)
+
+    def verify_sub_sub_response_updates(self, prefix, paths, path_value,
+                                        assert_fun=None,
+                                        subscription_mode=gnmi_pb2.SubscriptionList.ONCE,
+                                        poll_interval=0,
+                                        poll_count=0, read_count=-1):
+        if assert_fun is None:
+            assert_fun = TestGrpc.assert_updates
+        log.debug("paths=%s path_value=%s", paths, path_value)
+        response_count = 0
+        thread_assert = False
+        pv_idx = 0
+        for pv in path_value:
+            if not isinstance(pv, list):
+                pv_idx = -1
+                break
+        log.debug("pv_idx=%s", pv_idx)
+
+        def read_subscribe_responses(responses, read_count=-1):
+            nonlocal response_count, pv_idx, thread_assert
+            try:
+                for response in responses:
+                    response_count += 1
+                    log.debug("response=%s response_count=%i", response,
+                              response_count)
+                    assert (response.update.prefix == prefix)
+                    pv_to_check = path_value
+                    if pv_idx != -1:
+                        assert pv_idx < len(path_value)
+                        pv_to_check = path_value[pv_idx]
+                        pv_idx += 1
+                    if len(pv_to_check) > 0:  # skip empty arrays
+                        assert_fun(response.update.update, pv_to_check)
+                    log.info("response_count=%i", response_count)
+                    if read_count > 0:
+                        read_count -= 1
+                        if read_count == 0:
+                            log.info("read count reached")
+                            break
+                assert read_count == -1 or read_count == 0
+            except AssertionError as error:
+                log.exception(error)
+                thread_assert = True
+
+        read_thread = read_subscribe_responses
+        subscription_list = \
+            ConfDgNMIClient.make_subscription_list(prefix,
+                                                   paths,
+                                                   subscription_mode)
+
+        responses = self.client.subscribe(subscription_list,
+                                          read_thread=read_thread,
+                                          poll_interval=poll_interval,
+                                          poll_count=poll_count,
+                                          read_count=read_count)
+
+        assert thread_assert == False
+        log.debug("responses=%s", responses)
+        if poll_count:
+            assert (poll_count + 1 == response_count)
+
+    def _test_get_subscribe(self, is_subscribe=False,
+                            datatype=gnmi_pb2.GetRequest.DataType.CONFIG,
+                            subscription_mode=gnmi_pb2.SubscriptionList.ONCE,
+                            poll_interval=0,
+                            poll_count=0, read_count=-1):
+
+        kwargs = {"assert_fun": TestGrpc.assert_updates}
+        if_state_str = prefix_state_str = ""
         if datatype == gnmi_pb2.GetRequest.DataType.STATE:
-            prefix_state_str="-state"
+            prefix_state_str = "-state"
             if_state_str = "state_"
         prefix = make_gnmi_path("/interfaces{}".format(prefix_state_str))
+        kwargs["prefix"] = prefix
         if_id = 8
-        leaf_paths = [TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[0], if_state_str, if_id),
-                      TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[1], if_state_str, if_id)]
-        list_paths = [TestGrpc.mk_gnmi_if_path(self.list_paths_str[0], if_state_str, if_id),
-                      TestGrpc.mk_gnmi_if_path(self.list_paths_str[1], if_state_str, if_id)]
-
-        encoding = gnmi_pb2.Encoding.BYTES
-
-        def verify_get_updates(paths, pv_list,
-                               assert_fun=TestGrpc.assert_updates):
-            log.debug("paths=%s pv_list=%s", paths, pv_list)
-            notification = self.client.get(prefix, paths, datatype, encoding)
-            log.debug("notification=%s", notification)
-            for n in notification:
-                log.debug("n=%s", n)
-                assert (n.prefix == prefix)
-                assert_fun(n.update, pv_list)
-
-        subscription_mode = gnmi_pb2.SubscriptionList.ONCE
-
-        def verify_sub_updates(paths, pv_list,
-                               assert_fun=TestGrpc.assert_updates):
-            log.debug("paths=%s pv_list=%s", paths, pv_list)
-            subscription_list = ConfDgNMIClient.make_subscription_list(prefix,
-                                                                       paths,
-                                                                       subscription_mode)
-            responses = self.client.subscribe(subscription_list)
-            log.debug("responses=%s", responses)
-            for response in responses:
-                log.info("response=%s", response)
-                assert (response.update.prefix == prefix)
-                assert_fun(response.update.update, pv_list)
-
-        verify_updates = verify_get_updates
-        if is_subscribe:
-            verify_updates = verify_sub_updates
-
+        leaf_paths = [
+            TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[0], if_state_str,
+                                     if_id),
+            TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[1], if_state_str,
+                                     if_id)]
+        list_paths = [
+            TestGrpc.mk_gnmi_if_path(self.list_paths_str[0], if_state_str,
+                                     if_id),
+            TestGrpc.mk_gnmi_if_path(self.list_paths_str[1], if_state_str,
+                                     if_id)]
         ifname = "{}if_{}".format(if_state_str, if_id)
-        verify_updates([leaf_paths[0]],
-                       [(leaf_paths[0], ifname)])
-        verify_updates([leaf_paths[1]],
-                       [(leaf_paths[1], "gigabitEthernet")])
-        verify_updates(leaf_paths, [(leaf_paths[0], ifname),
-                                    (leaf_paths[1],
-                                     "gigabitEthernet")])
-        verify_updates([list_paths[0]],
-                       [(leaf_paths[0], ifname),
-                        (leaf_paths[1],
-                         "gigabitEthernet")])
+
+        if is_subscribe:
+            verify_response_updates = self.verify_sub_sub_response_updates
+            kwargs["subscription_mode"] = subscription_mode
+            kwargs["poll_interval"] = poll_interval
+            kwargs["poll_count"] = poll_count
+            kwargs["read_count"] = read_count
+        else:
+            encoding = gnmi_pb2.Encoding.BYTES
+            verify_response_updates = self.verify_get_response_updates
+            kwargs["datatype"] = datatype
+            kwargs["encoding"] = encoding
+
+        kwargs["paths"] = [leaf_paths[0]]
+        kwargs["path_value"] = [(leaf_paths[0], ifname)]
+        verify_response_updates(**kwargs)
+        kwargs["paths"] = [leaf_paths[1]]
+        kwargs["path_value"] = [(leaf_paths[1], "gigabitEthernet")]
+        verify_response_updates(**kwargs)
+        kwargs["paths"] = leaf_paths
+        kwargs["path_value"] = [(leaf_paths[0], ifname),
+                                (leaf_paths[1], "gigabitEthernet")]
+        verify_response_updates(**kwargs)
+        kwargs["paths"] = [list_paths[0]]
+        kwargs["path_value"] = [(leaf_paths[0], ifname), (leaf_paths[1],
+                                                          "gigabitEthernet")]
+        verify_response_updates(**kwargs)
         pv = []
         for i in range(1, GnmiDemoServerAdapter.num_of_ifs):
-            pv.append((TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[0], if_state_str, i),
+            pv.append((TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[0],
+                                                if_state_str, i),
                        "{}if_{}".format(if_state_str, i)))
-            pv.append((TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[1], if_state_str, i),
+            pv.append((TestGrpc.mk_gnmi_if_path(self.leaf_paths_str[1],
+                                                if_state_str, i),
                        "gigabitEthernet"))
-        verify_updates([list_paths[1]], pv,
-                       assert_fun=TestGrpc.assert_in_updates)
+        kwargs["paths"] = [list_paths[1]]
+        kwargs["path_value"] = pv
+        kwargs["assert_fun"] = TestGrpc.assert_in_updates
+        verify_response_updates(**kwargs)
+        pass
 
     @pytest.mark.parametrize("adapter_type",
                              [pytest.param(AdapterType.DEMO,
@@ -166,22 +248,175 @@ class TestGrpc(object):
     @pytest.mark.parametrize("data_type", ["CONFIG", "STATE"])
     def test_get(self, request, adapter_type, data_type):
         log.info("testing get")
-        datatype_map = {
-            "ALL": gnmi_pb2.GetRequest.DataType.ALL,
-            "CONFIG": gnmi_pb2.GetRequest.DataType.CONFIG,
-            "STATE": gnmi_pb2.GetRequest.DataType.STATE,
-            "OPERATIONAL": gnmi_pb2.GetRequest.DataType.OPERATIONAL,
-        }
-        self._test_get_subscribe_once(datatype=datatype_map[data_type])
+        self._test_get_subscribe(datatype=get_data_type(data_type))
 
     @pytest.mark.parametrize("adapter_type",
                              [pytest.param(AdapterType.DEMO,
                                            marks=[pytest.mark.demo]),
                               pytest.param(AdapterType.API,
                                            marks=[pytest.mark.confd])])
-    def test_subscribe_once(self, request, adapter_type):
+    @pytest.mark.parametrize("data_type", ["CONFIG", "STATE"])
+    def test_subscribe_once(self, request, adapter_type, data_type):
         log.info("testing subscribe_once")
-        self._test_get_subscribe_once(is_subscribe=True)
+        self._test_get_subscribe(is_subscribe=True,
+                                 datatype=get_data_type(data_type))
+
+    @pytest.mark.long
+    @pytest.mark.parametrize("adapter_type",
+                             [pytest.param(AdapterType.DEMO,
+                                           marks=[pytest.mark.demo]),
+                              pytest.param(AdapterType.API,
+                                           marks=[pytest.mark.confd])])
+    @pytest.mark.parametrize("data_type", ["CONFIG", "STATE"])
+    @pytest.mark.parametrize("poll_args",
+                             [(0.2, 2), (0.5, 2), (1, 2), (0.2, 10)])
+    def test_subscribe_poll(self, request, adapter_type, data_type, poll_args):
+        log.info("testing subscribe_poll")
+        self._test_get_subscribe(is_subscribe=True,
+                                 datatype=get_data_type(data_type),
+                                 subscription_mode=gnmi_pb2.SubscriptionList.POLL,
+                                 poll_interval=poll_args[0],
+                                 poll_count=poll_args[1])
+
+    def _send_change_list_to_confd_thread(self, prefix_str, changes_list):
+        log.info("==>")
+        log.debug("prefix_str=%s change_list=%s", prefix_str, changes_list)
+        oper_cmd = ""
+        config_cmd = ""
+        sleep(1)
+
+        def send_to_confd(config_cmd, oper_cmd):
+            def confd_cmd_subprocess(confd_cmd):
+                log.info("confd_cmd=%s", confd_cmd)
+                subprocess.run(confd_cmd, shell=True, check=True)
+
+            log.info("config_cmd=%s oper_cmd=%s", config_cmd, oper_cmd)
+            if config_cmd != "":
+                confd_cmd = "confd_cmd -c \"{}\"".format(
+                    config_cmd)
+                confd_cmd_subprocess(confd_cmd)
+            if oper_cmd != "":
+                confd_cmd = "confd_cmd -o -fr -c \"set {}\"".format(
+                    oper_cmd)
+                confd_cmd_subprocess(confd_cmd)
+
+        for c in changes_list:
+            log.debug("processing c=%s", c)
+            if isinstance(c, str) and c == "send":
+                send_to_confd(config_cmd, oper_cmd)
+                oper_cmd = config_cmd = ""
+                sleep(1)
+            else:
+                path_prefix = make_gnmi_path(prefix_str)
+                path = make_gnmi_path(c[0])
+                cmd = "{} {}".format(
+                    make_formatted_path(path, gnmi_prefix=path_prefix),
+                    c[1])
+                if "state" in prefix_str:
+                    oper_cmd += "{} ".format(cmd)
+                else:
+                    config_cmd += "mset {};".format(cmd)
+        log.info("<==")
+
+    @pytest.mark.long
+    @pytest.mark.parametrize("adapter_type",
+                             [pytest.param(AdapterType.DEMO,
+                                           marks=[pytest.mark.demo]),
+                              pytest.param(AdapterType.API,
+                                           marks=[pytest.mark.confd])
+                              ])
+    @pytest.mark.parametrize("data_type", ["CONFIG", "STATE"])
+    def test_subscribe_stream(self, request, adapter_type, data_type):
+        log.info("testing subscribe_stream")
+
+        if_state_str = prefix_state_str = ""
+        if data_type == "STATE":
+            prefix_state_str = "-state"
+            if_state_str = "state_"
+        prefix_str = "/interfaces{}".format(prefix_state_str)
+        prefix = make_gnmi_path(prefix_str)
+        paths = [TestGrpc.mk_gnmi_if_path(self.list_paths_str[1], if_state_str,
+                                          "N/A")]
+        changes_list = [
+            ("interface[name={}if_5]/type".format(if_state_str),
+             "fastEther"),
+            ("interface[name={}if_6]/type".format(if_state_str),
+             "fastEther"),
+            "send",
+            ("interface[name={}if_5]/type".format(if_state_str),
+             "gigabitEthernet"),
+            ("interface[name={}if_6]/type".format(if_state_str),
+             "gigabitEthernet"),
+            "send",
+        ]
+        if data_type == "STATE" and adapter_type == AdapterType.API:
+            # TODO state `confd_cmd` is not transactional, so we need to check
+            # every item - add 'send' after each item (fix checking method?)
+            new_change_list = []
+            must_send = True
+            for c in changes_list:
+                if c == "send":
+                    must_send = False
+                new_change_list.append(c)
+                if must_send:
+                    new_change_list.append("send")
+                    must_send = False
+                else:
+                    must_send = True
+            changes_list = new_change_list
+        log.info("change_list=%s", changes_list)
+
+        # create  config string
+        if adapter_type == AdapterType.DEMO:
+            demo = ET.Element("demo")
+            sub = ET.SubElement(demo, "subscription")
+            stream = ET.SubElement(sub, "STREAM")
+            changes = ET.SubElement(stream, "changes")
+
+        path_value = [[]]  # empty means no check
+        pv_idx = 1
+        for c in changes_list:
+            if isinstance(c, str):
+                if c == "send":
+                    pv_idx += 1
+            else:
+                if len(path_value) == pv_idx:
+                    path_value.append([])
+                path_value[pv_idx].append((make_gnmi_path(c[0]), c[1]))
+            if adapter_type == AdapterType.DEMO:
+                el = ET.SubElement(changes, "element")
+                if isinstance(c, str):
+                    el.text = c
+                else:
+                    ET.SubElement(el, "path").text = "{}/{}".format(prefix_str,
+                                                                    c[0])
+                    ET.SubElement(el, "val").text = c[1]
+
+        if adapter_type == AdapterType.DEMO:
+            xml_str = ET.tostring(demo, encoding='unicode')
+            log.debug("xml_str=%s", xml_str)
+            log.debug("path_value=%s", path_value)
+            GnmiDemoServerAdapter.load_config_string(xml_str)
+
+        kwargs = {"assert_fun": TestGrpc.assert_in_updates}
+        kwargs["prefix"] = prefix
+        kwargs["paths"] = paths
+        kwargs["path_value"] = path_value
+        kwargs["subscription_mode"] = gnmi_pb2.SubscriptionList.STREAM
+        kwargs["read_count"] = len(path_value)
+        kwargs["assert_fun"] = TestGrpc.assert_in_updates
+        if adapter_type == AdapterType.API:
+            sleep(1)
+            thr = threading.Thread(
+                target=self._send_change_list_to_confd_thread,
+                args=(prefix_str, changes_list, ))
+            thr.start()
+
+        self.verify_sub_sub_response_updates(**kwargs)
+
+        if adapter_type == AdapterType.API:
+            thr.join()
+        # TODO reset ConfD DB to original values
 
     @pytest.mark.parametrize("adapter_type",
                              [pytest.param(AdapterType.DEMO,


### PR DESCRIPTION
* changed capabilities (test) - as ConfD 7.5 uses different version for tailf-common
* plantuml github url for sources moved to ConfD-Developer, updated references in documentation
* added tests for poll subscription
* fix for race condition in streaming subscription, event and lock replaced with Queue
* refactoring, PEP fixes, comments
* STREAMing ON_CHANGE subscription for demo adapter + test, changes read from XML config file/string
* locking demo_db
* initial STREAMing subscription for ConfD adapter (supported leaf, list entry and lists) + tests
* support for state (operational) data in subscription
* updated client options for subscription
* documentation update, subscription UML seq. diagrams (with groovy)
* version 0.1.0

Signed-off-by: Michal Novak <micnovak@cisco.com>