### PR TITLE
support for json_ietf encoding (for get)

### DIFF
--- a/confdgnmi/src/confd_gnmi_adapter.py
+++ b/confdgnmi/src/confd_gnmi_adapter.py
@@ -49,10 +49,7 @@ class GnmiServerAdapter(ABC):
     @abstractmethod
     def set(self, prefix, updates):
         """
-        Set value for given path
-        TODO this is simple version for initial implementation
-        To reflect fully gNMI Set,
-        we should pass all delete, replace and update lists
+        Apply given updates.
         :param prefix: gNMI path prefix
         :param updates: gNMI updates (with path and val) to be set
         :return: gNMI UpdateResult operation
@@ -212,8 +209,8 @@ class GnmiServerAdapter(ABC):
 
         def changes(self):
             """
-            Get subscription response for changes (subscribed values).
-            `update` array contains changes
+            Get subscription responses for changes (subscribed values).
+            `update` arrays contain changes
             TODO `delete` is processed and `delete` array is empty
             TODO `alias` is dummy string, atomic is always False
             TODO timestamp is 0
@@ -221,10 +218,10 @@ class GnmiServerAdapter(ABC):
             """
             log.debug("==>")
             notifications = self.get_subscription_notifications()
-            response = [gnmi_pb2.SubscribeResponse(update=notif)
-                        for notif in notifications]
-            log.debug("<== response=%s", response)
-            return response
+            responses = [gnmi_pb2.SubscribeResponse(update=notif)
+                         for notif in notifications]
+            log.debug("<== responses=%s", responses)
+            return responses
 
         def get_subscription_notifications(self):
             update = self.get_monitored_changes()

--- a/confdgnmi/src/confd_gnmi_api_adapter.py
+++ b/confdgnmi/src/confd_gnmi_api_adapter.py
@@ -16,7 +16,7 @@ import gnmi_pb2
 from confd_gnmi_adapter import GnmiServerAdapter
 from confd_gnmi_api_adapter_defaults import ApiAdapterDefaults
 from confd_gnmi_common import make_xpath_path, make_formatted_path, \
-    prefix_gnmi_paths, remove_path_prefix, make_gnmi_path
+    add_path_prefix, remove_path_prefix, make_gnmi_path
 
 log = logging.getLogger('confd_gnmi_api_adapter')
 log.setLevel(logging.DEBUG)
@@ -111,7 +111,6 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
                     for prefix, updates in self._get_subscription_notifications()]
 
         def _get_subscription_notifications(self):
-            # TODO reuse with demo adapter ?
             with self.change_db_lock:
                 log.debug("self.change_db=%s", self.change_db)
                 assert len(self.change_db) > 0
@@ -141,7 +140,7 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
 
         def add_path_for_monitoring(self, path, prefix):
             log.debug("==>")
-            self.monitored_paths.append(prefix_gnmi_paths(path, prefix))
+            self.monitored_paths.append(add_path_prefix(path, prefix))
             log.debug("<==")
 
         @staticmethod

--- a/confdgnmi/src/confd_gnmi_common.py
+++ b/confdgnmi/src/confd_gnmi_common.py
@@ -167,7 +167,7 @@ def prefix_gnmi_paths(path, prefix):
 
 
 def remove_path_prefix(path, prefix):
-    assert path.elem[:len(prefix.elem)] == prefix.elem
+    assert path.elem[:len(prefix.elem)] == prefix.elem[:]
     return gnmi_pb2.Path(elem=path.elem[len(prefix.elem):],
                          origin=path.origin,
                          target=path.target)

--- a/confdgnmi/src/confd_gnmi_common.py
+++ b/confdgnmi/src/confd_gnmi_common.py
@@ -160,7 +160,7 @@ def make_formatted_path(gnmi_path, gnmi_prefix=None, quote_val=False) -> str:
     return path_str
 
 
-def prefix_gnmi_paths(path, prefix):
+def add_path_prefix(path, prefix):
     return gnmi_pb2.Path(elem=list(prefix.elem) + list(path.elem),
                          origin=path.origin,
                          target=path.target)

--- a/confdgnmi/src/confd_gnmi_demo_adapter.py
+++ b/confdgnmi/src/confd_gnmi_demo_adapter.py
@@ -13,12 +13,11 @@ from confd_gnmi_adapter import GnmiServerAdapter
 from confd_gnmi_common import make_xpath_path, make_gnmi_path
 
 log = logging.getLogger('confd_gnmi_demo_adapter')
-log.setLevel(logging.DEBUG)
 
 
 class GnmiDemoServerAdapter(GnmiServerAdapter):
-    NS_PREFIX="ietf-interfaces:"
-    NS_IANA="iana-if-type:"
+    NS_INTERFACES = "ietf-interfaces:"
+    NS_IANA = "iana-if-type:"
 
     # simple demo database
     # map with XPath, value - both strings
@@ -104,8 +103,7 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
 
     @staticmethod
     def _nsless_xpath(xpath: str):
-        return xpath.replace(GnmiDemoServerAdapter.NS_PREFIX, "")
-
+        return xpath.replace(GnmiDemoServerAdapter.NS_INTERFACES, "")
 
     @staticmethod
     def _get_key_from_xpath(xpath):
@@ -137,7 +135,6 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
             map_db[key] = elem_map
         log.debug("<== map_db={}".format(map_db))
         return map_db
-
 
     class SubscriptionHandler(GnmiServerAdapter.SubscriptionHandler):
 
@@ -459,7 +456,6 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
         ops = [(up.path, self.set_update(prefix, up.path, up.val))
                for up in updates]
 
-
         log.info("==> ops=%s", ops)
         return ops
 
@@ -469,4 +465,3 @@ class GnmiDemoServerAdapter(GnmiServerAdapter):
         # TODO
         log.info("==> ops=%s", ops)
         return ops
-

--- a/confdgnmi/tests/client_server_test_base.py
+++ b/confdgnmi/tests/client_server_test_base.py
@@ -372,7 +372,7 @@ class GrpcBase(object):
         path_value.extend(self._changes_list_to_pv(changes_list))
 
         prefix_str = "interfaces{}".format(prefix_state_str)
-        prefix = make_gnmi_path("/" + GnmiDemoServerAdapter.NS_PREFIX + prefix_str)
+        prefix = make_gnmi_path("/" + GnmiDemoServerAdapter.NS_INTERFACES + prefix_str)
 
         paths = [GrpcBase.mk_gnmi_if_path(self.list_paths_str[1], if_state_str,
                                           "N/A")]


### PR DESCRIPTION
Offering JSON_IETF as the only supported encoding, implemented JSON_IETF for get methods; fixed handling of prefixes.