### PR TITLE
confdgnmi - add logging setup for custom library + minor fixes to robot tests

### DIFF
--- a/confdgnmi/testtool/OpenConfig/01__interfaces.robot
+++ b/confdgnmi/testtool/OpenConfig/01__interfaces.robot
@@ -31,7 +31,7 @@ Get "interfaces" with "type" parameter
     [Documentation]    Verify that OK response is retrieved for ``GetRequest`` having ``type=``
     ...                parameter with any of the defined ``DataType``s.
     [Tags]  type
-    [Template]  Verify path "${path}" with DataType ${type}
+    [Template]  Iterate path "${path}" with DataType ${type}
     interfaces  ALL
     interfaces  CONFIG
     interfaces  STATE
@@ -41,7 +41,7 @@ Get "interfaces" for various "path" parameter values
     [Documentation]    Verify that various valid formats of root container/list
     ...                can be requested using ``path=`` parameter, and are responded to correctly.
     [Tags]  path  costly
-    [Template]    Verify Get of
+    [Template]    Iterate Get of
     # no namespace
     interfaces
     interfaces/interface
@@ -140,7 +140,7 @@ Get "config" response includes significant leaves
     [Documentation]    Verify that ``GetRequest`` with ``type=CONFIG`` parameter receives
     ...                OK response that does include standardized leaf names/items.
     [Tags]  config  leaf
-    [Template]    Get interface "config" includes leaf
+    [Template]    Iterate interface "config" includes leaf
     name
     type
     mtu
@@ -153,7 +153,7 @@ Get "state" response includes significant leaves
     ...                OK response that does include standardized leaf names/items.
     [Tags]  operational  leaf
     # TODO - add all items to verify deviation from full official OC YANG?
-    [Template]    Get interface "state" includes leaf
+    [Template]    Iterate interface "state" includes leaf
     name
     type
     mtu

--- a/confdgnmi/testtool/OpenConfig/02__if-ip.robot
+++ b/confdgnmi/testtool/OpenConfig/02__if-ip.robot
@@ -7,6 +7,7 @@ Default Tags      positive
 # Resource         ../gNMI_Interface/gNMIClient.resource
 # Suite Setup      Setup gNMI Client
 # Suite Teardown   Close gNMI Client
+# Test Teardown    Teardown gNMI state
 
 
 *** Test Cases ***

--- a/confdgnmi/testtool/OpenConfig/03__platform.robot
+++ b/confdgnmi/testtool/OpenConfig/03__platform.robot
@@ -7,6 +7,7 @@ Default Tags      positive
 # Resource         ../gNMI_Interface/gNMIClient.resource
 # Suite Setup      Setup gNMI Client
 # Suite Teardown   Close gNMI Client
+# Test Teardown    Teardown gNMI state
 
 
 *** Test Cases ***

--- a/confdgnmi/testtool/OpenConfig/interfaces.resource
+++ b/confdgnmi/testtool/OpenConfig/interfaces.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Resources specific to ``openconfig-interfaces.yang`` model.
-Library          ../gNMI_Interface/GetLibrary.py    ${DEFAULT_ENCODING}
+Library          ../gNMI_Interface/GetLibrary.py  ${DISABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
 Library    Collections
 Resource  openconfig.resource
 
@@ -12,12 +12,14 @@ Get container includes
     Verify Get of  ${path}
     Check last updates include   ${leaf_name}
 
-Get interface "config" includes leaf
+Iterate interface "config" includes leaf
     [Arguments]    ${leaf_name}
     DataType set to    CONFIG
     Get container includes  /interfaces/interface[name=${OC_INTERFACE}]/config  ${leaf_name}
+    [Teardown]    Teardown gNMI state
 
-Get interface "state" includes leaf
+Iterate interface "state" includes leaf
     [Arguments]    ${leaf_name}
     DataType set to    OPERATIONAL
     Get container includes  /interfaces/interface[name=${OC_INTERFACE}]/state  ${leaf_name}
+    [Teardown]    Teardown gNMI state

--- a/confdgnmi/testtool/OpenConfig/interfaces.resource
+++ b/confdgnmi/testtool/OpenConfig/interfaces.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Resources specific to ``openconfig-interfaces.yang`` model.
-Library          ../gNMI_Interface/GetLibrary.py  ${DISABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
+Library          ../gNMI_Interface/GetLibrary.py  ${ENABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
 Library    Collections
 Resource  openconfig.resource
 

--- a/confdgnmi/testtool/OpenConfig/openconfig.resource
+++ b/confdgnmi/testtool/OpenConfig/openconfig.resource
@@ -18,13 +18,6 @@ Iterate Get of
     Verify Get of  ${path}
     [Teardown]    Teardown gNMI state
 
-# Verify Get of "{path}" with supported encodings
-#     Get Capabilities From Device
-#     ${supported_encodings}=  Last Supported Encodings
-#     FOR  ${encoding}  IN  @{supported_encodings}
-#         Log    ${encoding}
-#     END
-
 Get data from
     [Arguments]  ${path}
     [Documentation]    Verify that Get RPC succeeds for specified path,

--- a/confdgnmi/testtool/OpenConfig/openconfig.resource
+++ b/confdgnmi/testtool/OpenConfig/openconfig.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation    Resources specific to OpenConfig telemetry testing.
-Library          ../gNMI_Interface/GetLibrary.py    ${DEFAULT_ENCODING}
+Library          ../gNMI_Interface/GetLibrary.py  ${DISABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
+Resource    ../gNMI_Interface/gNMIClient.resource
 
 *** Keywords ***
 
@@ -12,12 +13,17 @@ Verify Get of
     When Dispatch Get Request
     Then Should Received Ok Response
 
-Verify Get of "{path}" with supported encodings
-    Get Capabilities From Device
-    ${supported_encodings}=  Last Supported Encodings
-    FOR  ${encoding}  IN  @{supported_encodings}
-        Log    ${encoding}
-    END
+Iterate Get of
+    [Arguments]  ${path}
+    Verify Get of  ${path}
+    [Teardown]    Teardown gNMI state
+
+# Verify Get of "{path}" with supported encodings
+#     Get Capabilities From Device
+#     ${supported_encodings}=  Last Supported Encodings
+#     FOR  ${encoding}  IN  @{supported_encodings}
+#         Log    ${encoding}
+#     END
 
 Get data from
     [Arguments]  ${path}
@@ -28,8 +34,9 @@ Get data from
     [Return]  ${response}
 
 
-Verify path "${path}" with DataType ${type}
+Iterate path "${path}" with DataType ${type}
     Given Paths include  ${path}
     and DataType set to  ${type}
     When Dispatch Get Request
     Then Should Received Ok Response
+    [Teardown]    Teardown gNMI state

--- a/confdgnmi/testtool/OpenConfig/openconfig.resource
+++ b/confdgnmi/testtool/OpenConfig/openconfig.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Resources specific to OpenConfig telemetry testing.
-Library          ../gNMI_Interface/GetLibrary.py  ${DISABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
+Library          ../gNMI_Interface/GetLibrary.py  ${ENABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
 Resource    ../gNMI_Interface/gNMIClient.resource
 
 *** Keywords ***

--- a/confdgnmi/testtool/adapter.yaml
+++ b/confdgnmi/testtool/adapter.yaml
@@ -4,3 +4,5 @@ username: admin
 password: admin
 insecure: true
 default_encoding: # "None" for no overload of default encoding for Get requests
+
+disable_extra_logs: True # configuration of gNMI library - whether to disable internal implementation logs

--- a/confdgnmi/testtool/adapter.yaml
+++ b/confdgnmi/testtool/adapter.yaml
@@ -5,4 +5,4 @@ password: admin
 insecure: true
 default_encoding: # "None" for no overload of default encoding for Get requests
 
-disable_extra_logs: True # configuration of gNMI library - whether to disable internal implementation logs
+enable_extra_logs: False # configuration of gNMI library - whether to enable internal implementation logs

--- a/confdgnmi/testtool/gNMIRobotLibrary.py
+++ b/confdgnmi/testtool/gNMIRobotLibrary.py
@@ -11,9 +11,9 @@ class gNMIRobotLibrary(ABC):
     last_exception: Optional[Exception] = None
 
     """ Common gNMI related functionality used across Robot tests and all libraries inheriting. """
-    def __init__(self, disable_extra_logs = True) -> None:
+    def __init__(self, enable_extra_logs = False) -> None:
         self._client: Optional[ConfDgNMIClient] = None
-        if disable_extra_logs:
+        if not enable_extra_logs:
             # disable all confg_gnmi_ loggers to not pollute robot logs
             for name in logging.root.manager.loggerDict:
                 if name.startswith('confd_gnmi_'):

--- a/confdgnmi/testtool/gNMIRobotLibrary.py
+++ b/confdgnmi/testtool/gNMIRobotLibrary.py
@@ -1,4 +1,5 @@
 from abc import ABC
+import logging
 from typing import Dict, Optional
 from robot.api.logger import trace
 from confd_gnmi_client import ConfDgNMIClient
@@ -10,8 +11,15 @@ class gNMIRobotLibrary(ABC):
     last_exception: Optional[Exception] = None
 
     """ Common gNMI related functionality used across Robot tests and all libraries inheriting. """
-    def __init__(self) -> None:
+    def __init__(self, disable_extra_logs = True) -> None:
         self._client: Optional[ConfDgNMIClient] = None
+        if disable_extra_logs:
+            # disable all confg_gnmi_ loggers to not pollute robot logs
+            for name in logging.root.manager.loggerDict:
+                if name.startswith('confd_gnmi_'):
+                    logging.getLogger(name).disabled = True
+            # but keep the RPC one...
+            logging.getLogger('confd_gnmi_rpc').disabled = False
 
     def setup_client(self, host, port, username, passwd, insecure):
         """ Initialize new gNMI client instance for dispatching the requests to server. """

--- a/confdgnmi/testtool/gNMI_Interface/02__Get.robot
+++ b/confdgnmi/testtool/gNMI_Interface/02__Get.robot
@@ -35,7 +35,7 @@ Parameter "type" - valid values return OK response
     ...                (while not setting any other request parameters).
     ...
     ...                Test succeeds when "OK" response with any data is received from server.
-    [Template]         Verify Get with DataType
+    [Template]         Iterate Get with DataType
     ALL
     CONFIG
     STATE

--- a/confdgnmi/testtool/gNMI_Interface/Capabilities.resource
+++ b/confdgnmi/testtool/gNMI_Interface/Capabilities.resource
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation    Resources specific to gNMI ``Capabilities`` RPC/operation.
 Library          Collections
-Library          CapabilitiesLibrary.py  ${DISABLE_EXTRA_LOGS}
+Library          CapabilitiesLibrary.py  ${ENABLE_EXTRA_LOGS}
 
 
 *** Keywords ***

--- a/confdgnmi/testtool/gNMI_Interface/Capabilities.resource
+++ b/confdgnmi/testtool/gNMI_Interface/Capabilities.resource
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation    Resources specific to gNMI ``Capabilities`` RPC/operation.
 Library          Collections
-Library          CapabilitiesLibrary.py
+Library          CapabilitiesLibrary.py  ${DISABLE_EXTRA_LOGS}
 
 
 *** Keywords ***

--- a/confdgnmi/testtool/gNMI_Interface/CapabilitiesLibrary.py
+++ b/confdgnmi/testtool/gNMI_Interface/CapabilitiesLibrary.py
@@ -20,8 +20,8 @@ def empty_capabilities_data():
 class CapabilitiesLibrary(gNMIRobotLibrary):
     ROBOT_LIBRARY_SCOPE = 'SUITE'
 
-    def __init__(self, disable_extra_logs = True) -> None:
-        super().__init__(disable_extra_logs)
+    def __init__(self, enable_extra_logs = False) -> None:
+        super().__init__(enable_extra_logs)
         self._capabilities_data = empty_capabilities_data()
 
     def cleanup_capabilities(self) -> None:

--- a/confdgnmi/testtool/gNMI_Interface/CapabilitiesLibrary.py
+++ b/confdgnmi/testtool/gNMI_Interface/CapabilitiesLibrary.py
@@ -20,8 +20,8 @@ def empty_capabilities_data():
 class CapabilitiesLibrary(gNMIRobotLibrary):
     ROBOT_LIBRARY_SCOPE = 'SUITE'
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, disable_extra_logs = True) -> None:
+        super().__init__(disable_extra_logs)
         self._capabilities_data = empty_capabilities_data()
 
     def cleanup_capabilities(self) -> None:

--- a/confdgnmi/testtool/gNMI_Interface/Get.resource
+++ b/confdgnmi/testtool/gNMI_Interface/Get.resource
@@ -1,9 +1,10 @@
 *** Settings ***
 Documentation    Resources specific to gNMI ``Get`` RPC/operation.
-Library          GetLibrary.py    ${DEFAULT_ENCODING}
+Library          GetLibrary.py  ${DISABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
+Resource    gNMIClient.resource
 
 *** Keywords ***
-Verify Get with DataType
+Iterate Get with DataType
     [Documentation]    Try sending `GetRequest` with specified DataType parameter value,
     ...                and verify that "ok" response is received.
     [Tags]    type
@@ -11,6 +12,7 @@ Verify Get with DataType
     Given DataType set to  ${type}
     When Dispatch Get Request
     Then Should Received Ok Response
+    [Teardown]    Teardown gNMI state
 
 Verify Get with Encoding
     [Documentation]    Try sending `GetRequest` with specified Encoding parameter value,

--- a/confdgnmi/testtool/gNMI_Interface/Get.resource
+++ b/confdgnmi/testtool/gNMI_Interface/Get.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Resources specific to gNMI ``Get`` RPC/operation.
-Library          GetLibrary.py  ${DISABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
+Library          GetLibrary.py  ${ENABLE_EXTRA_LOGS}  ${DEFAULT_ENCODING}
 Resource    gNMIClient.resource
 
 *** Keywords ***

--- a/confdgnmi/testtool/gNMI_Interface/GetLibrary.py
+++ b/confdgnmi/testtool/gNMI_Interface/GetLibrary.py
@@ -53,8 +53,8 @@ class GetLibrary(CapabilitiesLibrary):
     default_encoding: Optional[str]
     params: GetRequestParameters
 
-    def __init__(self, disable_extra_logs = True, default_encoding: str = None) -> None:
-        super().__init__(disable_extra_logs)
+    def __init__(self, enable_extra_logs = False, default_encoding: str = None) -> None:
+        super().__init__(enable_extra_logs)
         self.default_encoding = encoding_str_to_int(default_encoding) if default_encoding is not None else None
         self.params = GetRequestParameters()
 

--- a/confdgnmi/testtool/gNMI_Interface/GetLibrary.py
+++ b/confdgnmi/testtool/gNMI_Interface/GetLibrary.py
@@ -17,11 +17,6 @@ class GetRequestParameters:
     encoding: int = None
     use_models: List[dict] = None
 
-    @staticmethod
-    def new():
-        """ Returns new instance of GetRequest parameters' placeholder. """
-        return GetRequestParameters()
-
     def to_kwargs(self, default_encoding: Optional[int]):
         return {
             'prefix': self.prefix,
@@ -36,14 +31,18 @@ class GetRequestParameters:
 @dataclass
 class UpdatePayload:
     path: str
+    value_type: str
     value: Dict[str, object]
 
     @staticmethod
     def from_obj(updateObj):
         path = _make_string_path(updateObj.path, xpath=True)
         # TODO - bug - fix for proper data types/encodings/values...
-        value = json.loads(updateObj.val.json_ietf_val)
-        return UpdatePayload(path=path, value=value)
+        (value_type, dict_data) = str(updateObj.val).split(': ', 1)
+        value = json.loads(dict_data)
+        if isinstance(value, str) and len(value) > 0:
+            value = json.loads(value)
+        return UpdatePayload(path=path, value_type=value_type, value=value)
 
 
 class GetLibrary(CapabilitiesLibrary):
@@ -54,10 +53,10 @@ class GetLibrary(CapabilitiesLibrary):
     default_encoding: Optional[str]
     params: GetRequestParameters
 
-    def __init__(self, default_encoding: str = None) -> None:
-        super().__init__()
+    def __init__(self, disable_extra_logs = True, default_encoding: str = None) -> None:
+        super().__init__(disable_extra_logs)
         self.default_encoding = encoding_str_to_int(default_encoding) if default_encoding is not None else None
-        self.params = GetRequestParameters.new()
+        self.params = GetRequestParameters()
 
     def get_last_updates_count(self):
         """ Return total number of updates in last response payload,
@@ -80,7 +79,7 @@ class GetLibrary(CapabilitiesLibrary):
 
     def cleanup_getrequest_parameters(self):
         """ Clear all parameters of following `GetRequest` to be empty. """
-        self.params = GetRequestParameters.new()
+        self.params = GetRequestParameters()
 
     def prefix_set_to(self, prefix: str):
         """ Set the `prefix` parameter of the next `GetRequest` to specified value. """
@@ -126,22 +125,22 @@ class GetLibrary(CapabilitiesLibrary):
         updates = []
         for n in notifications:
             for update in n.update:
-                trace(update)
                 updates.append(UpdatePayload.from_obj(update))
+        trace(f"Last updates: {str(updates)}")
         return updates
 
     def _updates_include(self, text: str) -> bool:
         updates = self.get_last_flattened_updates()
         if updates is None:
             return False
-        trace(updates)
+        # TODO - fix for nested items etc.
         return any(text in update.value for update in updates)
 
     def check_last_updates_include(self, text: str) -> bool:
-        assert self._updates_include(text), f'Wanted text \"{text}\" not found in any of updates'
+        assert self._updates_include(text), f'Expected \"{text}\" not found in any of updates'
 
     def check_last_updates_not_include(self, text: str) -> bool:
-        assert not self._updates_include(text), f'Unwanted text \"{text}\" found in some of updates'
+        assert not self._updates_include(text), f'Unexpected \"{text}\" found in some of updates'
 
     def test_teardown(self):
         super().test_teardown()

--- a/confdgnmi/testtool/gNMI_Interface/Subscribe.resource
+++ b/confdgnmi/testtool/gNMI_Interface/Subscribe.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Resources specific to gNMI Subscribe operation.
-Library          SubscribeLibrary.py
+Library          SubscribeLibrary.py  ${DISABLE_EXTRA_LOGS}
 Resource         gNMIClient.resource
 
 

--- a/confdgnmi/testtool/gNMI_Interface/Subscribe.resource
+++ b/confdgnmi/testtool/gNMI_Interface/Subscribe.resource
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    Resources specific to gNMI Subscribe operation.
-Library          SubscribeLibrary.py  ${DISABLE_EXTRA_LOGS}
+Library          SubscribeLibrary.py  ${ENABLE_EXTRA_LOGS}
 Resource         gNMIClient.resource
 
 

--- a/confdgnmi/testtool/nokia.yaml
+++ b/confdgnmi/testtool/nokia.yaml
@@ -4,3 +4,5 @@ username: admin
 password: admin
 insecure: false
 default_encoding: JSON_IETF
+
+disable_extra_logs: True # configuration of gNMI library - whether to disable internal implementation logs

--- a/confdgnmi/testtool/nokia.yaml
+++ b/confdgnmi/testtool/nokia.yaml
@@ -5,4 +5,4 @@ password: admin
 insecure: false
 default_encoding: JSON_IETF
 
-disable_extra_logs: True # configuration of gNMI library - whether to disable internal implementation logs
+enable_extra_logs: False # configuration of gNMI library - whether to enable internal implementation logs

--- a/confdgnmi/testtool/xr.yaml
+++ b/confdgnmi/testtool/xr.yaml
@@ -6,5 +6,7 @@ password: admin
 insecure: true
 default_encoding: JSON_IETF # as mandatory JSON is not supported
 
+disable_extra_logs: True # configuration of gNMI library - whether to disable internal implementation logs
+
 # test-case specific settings
 oc_interface: MgmtEth0/RP0/CPU0/0

--- a/confdgnmi/testtool/xr.yaml
+++ b/confdgnmi/testtool/xr.yaml
@@ -6,7 +6,7 @@ password: admin
 insecure: true
 default_encoding: JSON_IETF # as mandatory JSON is not supported
 
-disable_extra_logs: True # configuration of gNMI library - whether to disable internal implementation logs
+enable_extra_logs: False # configuration of gNMI library - whether to enable internal implementation logs
 
 # test-case specific settings
 oc_interface: MgmtEth0/RP0/CPU0/0


### PR DESCRIPTION
- fix cleanup of `[Template]` tests
- add ability to enable all the internal loggers of ConfC gNMI client
  (only RPC requests/responses enabled by default, others disabled)